### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 4
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/src/camodocal/EigenUtils.h
+++ b/src/camodocal/EigenUtils.h
@@ -5,38 +5,31 @@
 
 #include "ceres/rotation.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-template<typename T>
-T square(const T & m)
-{
-    return m * m;
-}
+template <typename T> T square(const T& m) { return m * m; }
 
 // Returns the 3D cross product skew symmetric matrix of a given 3D vector
-template<typename T>
-Eigen::Matrix<T, 3, 3> skew(const Eigen::Matrix<T, 3, 1>& vec)
-{
-    return (Eigen::Matrix<T, 3, 3>() << T(0), -vec(2), vec(1),
-                                        vec(2), T(0), -vec(0),
-                                        -vec(1), vec(0), T(0)).finished();
+template <typename T>
+Eigen::Matrix<T, 3, 3> skew(const Eigen::Matrix<T, 3, 1>& vec) {
+    return (Eigen::Matrix<T, 3, 3>() << T(0), -vec(2), vec(1), vec(2), T(0),
+            -vec(0), -vec(1), vec(0), T(0))
+        .finished();
 }
 
-template<typename Derived>
-typename Eigen::MatrixBase<Derived>::PlainObject sqrtm(const Eigen::MatrixBase<Derived>& A)
-{
+template <typename Derived>
+typename Eigen::MatrixBase<Derived>::PlainObject
+sqrtm(const Eigen::MatrixBase<Derived>& A) {
     Eigen::SelfAdjointEigenSolver<typename Derived::PlainObject> es(A);
 
     return es.operatorSqrt();
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 3> AngleAxisToRotationMatrix(const Eigen::Matrix<T, 3, 1>& rvec)
-{
+template <typename T>
+Eigen::Matrix<T, 3, 3>
+AngleAxisToRotationMatrix(const Eigen::Matrix<T, 3, 1>& rvec) {
     T angle = rvec.norm();
-    if (angle == T(0))
-    {
+    if (angle == T(0)) {
         return Eigen::Matrix<T, 3, 3>::Identity();
     }
 
@@ -49,17 +42,15 @@ Eigen::Matrix<T, 3, 3> AngleAxisToRotationMatrix(const Eigen::Matrix<T, 3, 1>& r
     return rmat;
 }
 
-template<typename T>
-Eigen::Quaternion<T> AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec)
-{
+template <typename T>
+Eigen::Quaternion<T> AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec) {
     Eigen::Matrix<T, 3, 3> rmat = AngleAxisToRotationMatrix<T>(rvec);
 
     return Eigen::Quaternion<T>(rmat);
 }
 
-template<typename T>
-void AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec, T* q)
-{
+template <typename T>
+void AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec, T* q) {
     Eigen::Quaternion<T> quat = AngleAxisToQuaternion<T>(rvec);
 
     q[0] = quat.x();
@@ -68,18 +59,15 @@ void AngleAxisToQuaternion(const Eigen::Matrix<T, 3, 1>& rvec, T* q)
     q[3] = quat.w();
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 1> RotationToAngleAxis(const Eigen::Matrix<T, 3, 3> & rmat)
-{
+template <typename T>
+Eigen::Matrix<T, 3, 1> RotationToAngleAxis(const Eigen::Matrix<T, 3, 3>& rmat) {
     Eigen::AngleAxis<T> angleaxis;
     angleaxis.fromRotationMatrix(rmat);
     return angleaxis.angle() * angleaxis.axis();
-
 }
 
-template<typename T>
-void QuaternionToAngleAxis(const T* const q, Eigen::Matrix<T, 3, 1>& rvec)
-{
+template <typename T>
+void QuaternionToAngleAxis(const T* const q, Eigen::Matrix<T, 3, 1>& rvec) {
     Eigen::Quaternion<T> quat(q[3], q[0], q[1], q[2]);
 
     Eigen::Matrix<T, 3, 3> rmat = quat.toRotationMatrix();
@@ -90,63 +78,53 @@ void QuaternionToAngleAxis(const T* const q, Eigen::Matrix<T, 3, 1>& rvec)
     rvec = angleaxis.angle() * angleaxis.axis();
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 3> QuaternionToRotation(const T* const q)
-{
+template <typename T>
+Eigen::Matrix<T, 3, 3> QuaternionToRotation(const T* const q) {
     T R[9];
     ceres::QuaternionToRotation(q, R);
 
     Eigen::Matrix<T, 3, 3> rmat;
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            rmat(i,j) = R[i * 3 + j];
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            rmat(i, j) = R[i * 3 + j];
         }
     }
 
     return rmat;
 }
 
-template<typename T>
-void QuaternionToRotation(const T* const q, T* rot)
-{
+template <typename T> void QuaternionToRotation(const T* const q, T* rot) {
     ceres::QuaternionToRotation(q, rot);
 }
 
-template<typename T>
-Eigen::Matrix<T,4,4> QuaternionMultMatLeft(const Eigen::Quaternion<T>& q)
-{
-    return (Eigen::Matrix<T,4,4>() << q.w(), -q.z(), q.y(), q.x(),
-                                      q.z(), q.w(), -q.x(), q.y(),
-                                      -q.y(), q.x(), q.w(), q.z(),
-                                      -q.x(), -q.y(), -q.z(), q.w()).finished();
+template <typename T>
+Eigen::Matrix<T, 4, 4> QuaternionMultMatLeft(const Eigen::Quaternion<T>& q) {
+    return (Eigen::Matrix<T, 4, 4>() << q.w(), -q.z(), q.y(), q.x(), q.z(),
+            q.w(), -q.x(), q.y(), -q.y(), q.x(), q.w(), q.z(), -q.x(), -q.y(),
+            -q.z(), q.w())
+        .finished();
 }
 
-template<typename T>
-Eigen::Matrix<T,4,4> QuaternionMultMatRight(const Eigen::Quaternion<T>& q)
-{
-    return (Eigen::Matrix<T,4,4>() << q.w(), q.z(), -q.y(), q.x(),
-                                      -q.z(), q.w(), q.x(), q.y(),
-                                      q.y(), -q.x(), q.w(), q.z(),
-                                      -q.x(), -q.y(), -q.z(), q.w()).finished();
+template <typename T>
+Eigen::Matrix<T, 4, 4> QuaternionMultMatRight(const Eigen::Quaternion<T>& q) {
+    return (Eigen::Matrix<T, 4, 4>() << q.w(), q.z(), -q.y(), q.x(), -q.z(),
+            q.w(), q.x(), q.y(), q.y(), -q.x(), q.w(), q.z(), -q.x(), -q.y(),
+            -q.z(), q.w())
+        .finished();
 }
 
 /// @param theta - rotation about screw axis
 /// @param d - projection of tvec on the rotation axis
 /// @param l - screw axis direction
 /// @param m - screw axis moment
-template<typename T>
+template <typename T>
 void AngleAxisAndTranslationToScrew(const Eigen::Matrix<T, 3, 1>& rvec,
                                     const Eigen::Matrix<T, 3, 1>& tvec,
-                                    T& theta, T& d,
-                                    Eigen::Matrix<T, 3, 1>& l,
-                                    Eigen::Matrix<T, 3, 1>& m)
-{
+                                    T& theta, T& d, Eigen::Matrix<T, 3, 1>& l,
+                                    Eigen::Matrix<T, 3, 1>& m) {
 
     theta = rvec.norm();
-    if (theta == 0)
-    {
+    if (theta == 0) {
         l.setZero();
         m.setZero();
         std::cout << "Warning: Undefined screw! Returned 0. " << std::endl;
@@ -166,9 +144,7 @@ void AngleAxisAndTranslationToScrew(const Eigen::Matrix<T, 3, 1>& rvec,
     m = c.cross(l);
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 3> RPY2mat(T roll, T pitch, T yaw)
-{
+template <typename T> Eigen::Matrix<T, 3, 3> RPY2mat(T roll, T pitch, T yaw) {
     Eigen::Matrix<T, 3, 3> m;
 
     T cr = cos(roll);
@@ -178,108 +154,102 @@ Eigen::Matrix<T, 3, 3> RPY2mat(T roll, T pitch, T yaw)
     T cy = cos(yaw);
     T sy = sin(yaw);
 
-    m(0,0) = cy * cp;
-    m(0,1) = cy * sp * sr - sy * cr;
-    m(0,2) = cy * sp * cr + sy * sr;
-    m(1,0) = sy * cp;
-    m(1,1) = sy * sp * sr + cy * cr;
-    m(1,2) = sy * sp * cr - cy * sr;
-    m(2,0) = - sp;
-    m(2,1) = cp * sr;
-    m(2,2) = cp * cr;
+    m(0, 0) = cy * cp;
+    m(0, 1) = cy * sp * sr - sy * cr;
+    m(0, 2) = cy * sp * cr + sy * sr;
+    m(1, 0) = sy * cp;
+    m(1, 1) = sy * sp * sr + cy * cr;
+    m(1, 2) = sy * sp * cr - cy * sr;
+    m(2, 0) = -sp;
+    m(2, 1) = cp * sr;
+    m(2, 2) = cp * cr;
     return m;
 }
 
-template<typename T>
-void mat2RPY(const Eigen::Matrix<T, 3, 3>& m, T& roll, T& pitch, T& yaw)
-{
-    roll = atan2(m(2,1), m(2,2));
-    pitch = atan2(-m(2,0), sqrt(m(2,1) * m(2,1) + m(2,2) * m(2,2)));
-    yaw = atan2(m(1,0), m(0,0));
+template <typename T>
+void mat2RPY(const Eigen::Matrix<T, 3, 3>& m, T& roll, T& pitch, T& yaw) {
+    roll = atan2(m(2, 1), m(2, 2));
+    pitch = atan2(-m(2, 0), sqrt(m(2, 1) * m(2, 1) + m(2, 2) * m(2, 2)));
+    yaw = atan2(m(1, 0), m(0, 0));
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4> homogeneousTransform(const Eigen::Matrix<T, 3, 3>& R, const Eigen::Matrix<T, 3, 1>& t)
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> homogeneousTransform(const Eigen::Matrix<T, 3, 3>& R,
+                                            const Eigen::Matrix<T, 3, 1>& t) {
     Eigen::Matrix<T, 4, 4> H;
     H.setIdentity();
 
-    H.block(0,0,3,3) = R;
-    H.block(0,3,3,1) = t;
+    H.block(0, 0, 3, 3) = R;
+    H.block(0, 3, 3, 1) = t;
 
     return H;
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4> poseWithCartesianTranslation(const T* const q, const T* const p)
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> poseWithCartesianTranslation(const T* const q,
+                                                    const T* const p) {
     Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
 
     T rotation[9];
     ceres::QuaternionToRotation(q, rotation);
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            pose(i,j) = rotation[i * 3 + j];
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            pose(i, j) = rotation[i * 3 + j];
         }
     }
 
-    pose(0,3) = p[0];
-    pose(1,3) = p[1];
-    pose(2,3) = p[2];
+    pose(0, 3) = p[0];
+    pose(1, 3) = p[1];
+    pose(2, 3) = p[2];
 
     return pose;
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4> poseWithSphericalTranslation(const T* const q, const T* const p, const T scale = T(1.0))
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> poseWithSphericalTranslation(const T* const q,
+                                                    const T* const p,
+                                                    const T scale = T(1.0)) {
     Eigen::Matrix<T, 4, 4> pose = Eigen::Matrix<T, 4, 4>::Identity();
 
     T rotation[9];
     ceres::QuaternionToRotation(q, rotation);
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            pose(i,j) = rotation[i * 3 + j];
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            pose(i, j) = rotation[i * 3 + j];
         }
     }
 
     T theta = p[0];
     T phi = p[1];
-    pose(0,3) = sin(theta) * cos(phi) * scale;
-    pose(1,3) = sin(theta) * sin(phi) * scale;
-    pose(2,3) = cos(theta) * scale;
+    pose(0, 3) = sin(theta) * cos(phi) * scale;
+    pose(1, 3) = sin(theta) * sin(phi) * scale;
+    pose(2, 3) = cos(theta) * scale;
 
     return pose;
 }
 
 // Returns the Sampson error of a given essential matrix and 2 image points
-template<typename T>
+template <typename T>
 T sampsonError(const Eigen::Matrix<T, 3, 3>& E,
                const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
+               const Eigen::Matrix<T, 3, 1>& p2) {
     Eigen::Matrix<T, 3, 1> Ex1 = E * p1;
     Eigen::Matrix<T, 3, 1> Etx2 = E.transpose() * p2;
 
     T x2tEx1 = p2.dot(Ex1);
 
     // compute Sampson error
-    T err = square(x2tEx1) / (square(Ex1(0,0)) + square(Ex1(1,0)) + square(Etx2(0,0)) + square(Etx2(1,0)));
+    T err = square(x2tEx1) / (square(Ex1(0, 0)) + square(Ex1(1, 0)) +
+                              square(Etx2(0, 0)) + square(Etx2(1, 0)));
 
     return err;
 }
 
 // Returns the Sampson error of a given rotation/translation and 2 image points
-template<typename T>
-T sampsonError(const Eigen::Matrix<T, 3, 3>& R,
-               const Eigen::Matrix<T, 3, 1>& t,
+template <typename T>
+T sampsonError(const Eigen::Matrix<T, 3, 3>& R, const Eigen::Matrix<T, 3, 1>& t,
                const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
+               const Eigen::Matrix<T, 3, 1>& p2) {
     // construct essential matrix
     Eigen::Matrix<T, 3, 3> E = skew(t) * R;
 
@@ -289,43 +259,46 @@ T sampsonError(const Eigen::Matrix<T, 3, 3>& R,
     T x2tEx1 = p2.dot(Ex1);
 
     // compute Sampson error
-    T err = square(x2tEx1) / (square(Ex1(0,0)) + square(Ex1(1,0)) + square(Etx2(0,0)) + square(Etx2(1,0)));
+    T err = square(x2tEx1) / (square(Ex1(0, 0)) + square(Ex1(1, 0)) +
+                              square(Etx2(0, 0)) + square(Etx2(1, 0)));
 
     return err;
 }
 
 // Returns the Sampson error of a given rotation/translation and 2 image points
-template<typename T>
+template <typename T>
 T sampsonError(const Eigen::Matrix<T, 4, 4>& H,
                const Eigen::Matrix<T, 3, 1>& p1,
-               const Eigen::Matrix<T, 3, 1>& p2)
-{
+               const Eigen::Matrix<T, 3, 1>& p2) {
     Eigen::Matrix<T, 3, 3> R = H.block(0, 0, 3, 3);
     Eigen::Matrix<T, 3, 1> t = H.block(0, 3, 3, 1);
 
     return sampsonError(R, t, p1, p2);
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 1>
-transformPoint(const Eigen::Matrix<T, 4, 4>& H, const Eigen::Matrix<T, 3, 1>& P)
-{
-    Eigen::Matrix<T, 3, 1> P_trans = H.block(0, 0, 3, 3) * P + H.block(0, 3, 3, 1);
+template <typename T>
+Eigen::Matrix<T, 3, 1> transformPoint(const Eigen::Matrix<T, 4, 4>& H,
+                                      const Eigen::Matrix<T, 3, 1>& P) {
+    Eigen::Matrix<T, 3, 1> P_trans =
+        H.block(0, 0, 3, 3) * P + H.block(0, 3, 3, 1);
 
     return P_trans;
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4>
-estimate3DRigidTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points1,
-                         const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points2)
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> estimate3DRigidTransform(
+    const std::vector<Eigen::Matrix<T, 3, 1>,
+                      Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1>>>&
+        points1,
+    const std::vector<Eigen::Matrix<T, 3, 1>,
+                      Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1>>>&
+        points2) {
     // compute centroids
     Eigen::Matrix<T, 3, 1> c1, c2;
-    c1.setZero(); c2.setZero();
+    c1.setZero();
+    c2.setZero();
 
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    for (size_t i = 0; i < points1.size(); ++i) {
         c1 += points1.at(i);
         c2 += points2.at(i);
     }
@@ -335,20 +308,19 @@ estimate3DRigidTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligne
 
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    for (size_t i = 0; i < points1.size(); ++i) {
         X.col(i) = points1.at(i) - c1;
         Y.col(i) = points2.at(i) - c2;
     }
 
     Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
 
-    Eigen::JacobiSVD< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>> svd(
+        H, Eigen::ComputeFullU | Eigen::ComputeFullV);
 
     Eigen::Matrix<T, 3, 3> U = svd.matrixU();
     Eigen::Matrix<T, 3, 3> V = svd.matrixV();
-    if (U.determinant() * V.determinant() < 0.0)
-    {
+    if (U.determinant() * V.determinant() < 0.0) {
         V.col(2) *= -1.0;
     }
 
@@ -358,17 +330,20 @@ estimate3DRigidTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligne
     return homogeneousTransform(R, t);
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4>
-estimate3DRigidSimilarityTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points1,
-                                   const std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > >& points2)
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> estimate3DRigidSimilarityTransform(
+    const std::vector<Eigen::Matrix<T, 3, 1>,
+                      Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1>>>&
+        points1,
+    const std::vector<Eigen::Matrix<T, 3, 1>,
+                      Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1>>>&
+        points2) {
     // compute centroids
     Eigen::Matrix<T, 3, 1> c1, c2;
-    c1.setZero(); c2.setZero();
+    c1.setZero();
+    c2.setZero();
 
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    for (size_t i = 0; i < points1.size(); ++i) {
         c1 += points1.at(i);
         c2 += points2.at(i);
     }
@@ -378,34 +353,33 @@ estimate3DRigidSimilarityTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eig
 
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> X(3, points1.size());
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> Y(3, points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    for (size_t i = 0; i < points1.size(); ++i) {
         X.col(i) = points1.at(i) - c1;
         Y.col(i) = points2.at(i) - c2;
     }
 
     Eigen::Matrix<T, 3, 3> H = X * Y.transpose();
 
-    Eigen::JacobiSVD< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>> svd(
+        H, Eigen::ComputeFullU | Eigen::ComputeFullV);
 
     Eigen::Matrix<T, 3, 3> U = svd.matrixU();
     Eigen::Matrix<T, 3, 3> V = svd.matrixV();
-    if (U.determinant() * V.determinant() < 0.0)
-    {
+    if (U.determinant() * V.determinant() < 0.0) {
         V.col(2) *= -1.0;
     }
 
     Eigen::Matrix<T, 3, 3> R = V * U.transpose();
 
-    std::vector<Eigen::Matrix<T, 3, 1>, Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1> > > rotatedPoints1(points1.size());
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    std::vector<Eigen::Matrix<T, 3, 1>,
+                Eigen::aligned_allocator<Eigen::Matrix<T, 3, 1>>>
+        rotatedPoints1(points1.size());
+    for (size_t i = 0; i < points1.size(); ++i) {
         rotatedPoints1.at(i) = R * (points1.at(i) - c1);
     }
 
     double sum_ss = 0.0, sum_tt = 0.0;
-    for (size_t i = 0; i < points1.size(); ++i)
-    {
+    for (size_t i = 0; i < points1.size(); ++i) {
         sum_ss += (points1.at(i) - c1).squaredNorm();
         sum_tt += (points2.at(i) - c2).dot(rotatedPoints1.at(i));
     }
@@ -417,7 +391,6 @@ estimate3DRigidSimilarityTransform(const std::vector<Eigen::Matrix<T, 3, 1>, Eig
 
     return homogeneousTransform(sR, t);
 }
-
 }
 
 #endif

--- a/src/camodocal/calib/DualQuaternion.h
+++ b/src/camodocal/calib/DualQuaternion.h
@@ -6,35 +6,29 @@
 
 #include "QuaternionMapping.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-template<typename T>
-class DualQuaternion;
+template <typename T> class DualQuaternion;
 
 typedef DualQuaternion<float> DualQuaternionf;
 typedef DualQuaternion<double> DualQuaterniond;
 
-template<typename T>
-DualQuaternion<T>
-operator+(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
+template <typename T>
+DualQuaternion<T> operator+(const DualQuaternion<T>& dq1,
+                            const DualQuaternion<T>& dq2);
 
-template<typename T>
-DualQuaternion<T>
-operator-(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
+template <typename T>
+DualQuaternion<T> operator-(const DualQuaternion<T>& dq1,
+                            const DualQuaternion<T>& dq2);
 
-template<typename T>
-DualQuaternion<T>
-operator*(T scale, const DualQuaternion<T>& dq);
+template <typename T>
+DualQuaternion<T> operator*(T scale, const DualQuaternion<T>& dq);
 
-template<typename T>
-std::ostream &
-operator << (std::ostream &, const DualQuaternion<T> & ); 
+template <typename T>
+std::ostream& operator<<(std::ostream&, const DualQuaternion<T>&);
 
-template<typename T>
-class DualQuaternion
-{
-public:
+template <typename T> class DualQuaternion {
+  public:
     DualQuaternion();
     DualQuaternion(const Eigen::Quaternion<T>& r,
                    const Eigen::Quaternion<T>& d);
@@ -44,8 +38,7 @@ public:
     DualQuaternion<T> conjugate(void) const;
     Eigen::Quaternion<T> dual(void) const;
     DualQuaternion<T> exp(void) const;
-    void fromScrew(T theta, T d,
-                   const Eigen::Matrix<T, 3, 1>& l,
+    void fromScrew(T theta, T d, const Eigen::Matrix<T, 3, 1>& l,
                    const Eigen::Matrix<T, 3, 1>& m);
     static DualQuaternion<T> identity(void);
     DualQuaternion<T> inverse(void) const;
@@ -53,8 +46,10 @@ public:
     void norm(T& real, T& dual) const;
     void normalize(void);
     DualQuaternion<T> normalized(void) const;
-    Eigen::Matrix<T, 3, 1> transformPoint(const Eigen::Matrix<T, 3, 1>& point) const;
-    Eigen::Matrix<T, 3, 1> transformVector(const Eigen::Matrix<T, 3, 1>& vector) const;
+    Eigen::Matrix<T, 3, 1>
+    transformPoint(const Eigen::Matrix<T, 3, 1>& point) const;
+    Eigen::Matrix<T, 3, 1>
+    transformVector(const Eigen::Matrix<T, 3, 1>& vector) const;
     Eigen::Quaternion<T> real(void) const;
     Eigen::Quaternion<T> rotation(void) const;
     Eigen::Matrix<T, 3, 1> translation(void) const;
@@ -64,131 +59,104 @@ public:
 
     DualQuaternion<T> operator*(T scale) const;
     DualQuaternion<T> operator*(const DualQuaternion<T>& other) const;
-    friend DualQuaternion<T> operator+<>(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
-    friend DualQuaternion<T> operator-<>(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
-//    friend DualQuaternion<T> operator*<>(T scale, const DualQuaternion<T>& dq);
-    
-    friend std::ostream& operator << <> (std::ostream &, const DualQuaternion<T> &); 
+    friend DualQuaternion<T> operator+
+        <>(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
+    friend DualQuaternion<T> operator-
+        <>(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2);
+    //    friend DualQuaternion<T> operator*<>(T scale, const DualQuaternion<T>&
+    //    dq);
 
-private:
+    friend std::ostream& operator<<<>(std::ostream&, const DualQuaternion<T>&);
+
+  private:
     Eigen::Quaternion<T> m_real; // real part
     Eigen::Quaternion<T> m_dual; // dual part
 };
 
-template<typename T>
-DualQuaternion<T>::DualQuaternion()
-{
+template <typename T> DualQuaternion<T>::DualQuaternion() {
     m_real = Eigen::Quaternion<T>(1, 0, 0, 0);
     m_dual = Eigen::Quaternion<T>(0, 0, 0, 0);
 }
 
-template<typename T>
+template <typename T>
 DualQuaternion<T>::DualQuaternion(const Eigen::Quaternion<T>& r,
-                                  const Eigen::Quaternion<T>& d)
-{
+                                  const Eigen::Quaternion<T>& d) {
     m_real = r;
     m_dual = d;
 }
 
-template<typename T>
+template <typename T>
 DualQuaternion<T>::DualQuaternion(const Eigen::Quaternion<T>& r,
-                                  const Eigen::Matrix<T, 3, 1>& t)
-{
+                                  const Eigen::Matrix<T, 3, 1>& t) {
     m_real = r.normalized();
-    m_dual = Eigen::Quaternion<T>(T(0.5) * (Eigen::Quaternion<T>(T(0), t(0), t(1), t(2)) * m_real).coeffs());
+    m_dual = Eigen::Quaternion<T>(
+        T(0.5) *
+        (Eigen::Quaternion<T>(T(0), t(0), t(1), t(2)) * m_real).coeffs());
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::conjugate(void) const
-{
+template <typename T>
+DualQuaternion<T> DualQuaternion<T>::conjugate(void) const {
     return DualQuaternion<T>(m_real.conjugate(), m_dual.conjugate());
 }
 
-template<typename T>
-Eigen::Quaternion<T>
-DualQuaternion<T>::dual(void) const
-{
+template <typename T> Eigen::Quaternion<T> DualQuaternion<T>::dual(void) const {
     return m_dual;
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::exp(void) const
-{
+template <typename T> DualQuaternion<T> DualQuaternion<T>::exp(void) const {
     Eigen::Quaternion<T> real = expq(m_real);
     Eigen::Quaternion<T> dual = real * m_dual;
 
     return DualQuaternion<T>(real, dual);
 }
 
-template<typename T>
-void
-DualQuaternion<T>::fromScrew(T theta, T d,
-                             const Eigen::Matrix<T, 3, 1>& l,
-                             const Eigen::Matrix<T, 3, 1>& m)
-{
+template <typename T>
+void DualQuaternion<T>::fromScrew(T theta, T d, const Eigen::Matrix<T, 3, 1>& l,
+                                  const Eigen::Matrix<T, 3, 1>& m) {
     m_real = Eigen::AngleAxis<T>(theta, l);
     m_dual.w() = -d / 2.0 * sin(theta / 2.0);
     m_dual.vec() = sin(theta / 2.0) * m + d / 2.0 * cos(theta / 2.0) * l;
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::identity(void)
-{
+template <typename T> DualQuaternion<T> DualQuaternion<T>::identity(void) {
     return DualQuaternion<T>(Eigen::Quaternion<T>::Identity(),
                              Eigen::Quaternion<T>(0, 0, 0, 0));
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::inverse(void) const
-{
+template <typename T> DualQuaternion<T> DualQuaternion<T>::inverse(void) const {
     T sqrLen0 = m_real.squaredNorm();
     T sqrLenE = 2.0 * (m_real.coeffs().dot(m_dual.coeffs()));
 
-    if (sqrLen0 > 0.0)
-    {
+    if (sqrLen0 > 0.0) {
         T invSqrLen0 = 1.0 / sqrLen0;
         T invSqrLenE = -sqrLenE / (sqrLen0 * sqrLen0);
 
         DualQuaternion<T> conj = conjugate();
         conj.m_real.coeffs() = invSqrLen0 * conj.m_real.coeffs();
-        conj.m_dual.coeffs() = invSqrLen0 * conj.m_dual.coeffs() + invSqrLenE * conj.m_real.coeffs();
+        conj.m_dual.coeffs() = invSqrLen0 * conj.m_dual.coeffs() +
+                               invSqrLenE * conj.m_real.coeffs();
 
         return conj;
-    }
-    else
-    {
+    } else {
         return DualQuaternion<T>::zeros();
     }
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::log(void) const
-{
+template <typename T> DualQuaternion<T> DualQuaternion<T>::log(void) const {
     Eigen::Quaternion<T> real = logq(m_real);
     Eigen::Quaternion<T> dual = m_real.conjugate() * m_dual;
-    T scale = T(1) / m_real.squaredNorm(); 
-    dual.coeffs() *= scale; 
+    T scale = T(1) / m_real.squaredNorm();
+    dual.coeffs() *= scale;
 
     return DualQuaternion<T>(real, dual);
 }
 
-template<typename T>
-void
-DualQuaternion<T>::norm(T& real, T& dual) const
-{
+template <typename T> void DualQuaternion<T>::norm(T& real, T& dual) const {
     real = m_real.norm();
     dual = m_real.coeffs().dot(m_dual.coeffs()) / real;
 }
 
-template<typename T>
-void
-DualQuaternion<T>::normalize(void)
-{
+template <typename T> void DualQuaternion<T>::normalize(void) {
     T length = m_real.norm();
     T lengthSqr = m_real.squaredNorm();
 
@@ -197,66 +165,61 @@ DualQuaternion<T>::normalize(void)
 
     // real and dual parts are orthogonal
     m_dual.coeffs() /= length;
-    m_dual.coeffs() -= (m_real.coeffs().dot(m_dual.coeffs()) * lengthSqr) * m_real.coeffs();
+    m_dual.coeffs() -=
+        (m_real.coeffs().dot(m_dual.coeffs()) * lengthSqr) * m_real.coeffs();
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::normalized(void) const
-{
+template <typename T>
+DualQuaternion<T> DualQuaternion<T>::normalized(void) const {
     DualQuaternion<T> dq = *this;
     dq.normalize();
 
     return dq;
 }
 
-template<typename T>
+template <typename T>
 Eigen::Matrix<T, 3, 1>
-DualQuaternion<T>::transformPoint(const Eigen::Matrix<T, 3, 1>& point) const
-{
-    DualQuaternion<T> dq = (*this)
-                           * DualQuaternion<T>(Eigen::Quaternion<T>(1, 0, 0, 0),
-                                               Eigen::Quaternion<T>(0, point(0,0), point(1,0), point(2,0)))
-                           * conjugate();
+DualQuaternion<T>::transformPoint(const Eigen::Matrix<T, 3, 1>& point) const {
+    DualQuaternion<T> dq =
+        (*this) *
+        DualQuaternion<T>(
+            Eigen::Quaternion<T>(1, 0, 0, 0),
+            Eigen::Quaternion<T>(0, point(0, 0), point(1, 0), point(2, 0))) *
+        conjugate();
 
     Eigen::Matrix<T, 3, 1> p(dq.m_dual.x(), dq.m_dual.y(), dq.m_dual.z());
 
     // translation
-    p += 2.0 * (m_real.w() * m_dual.vec() - m_dual.w() * m_real.vec() + m_real.vec().cross(m_dual.vec()));
+    p += 2.0 * (m_real.w() * m_dual.vec() - m_dual.w() * m_real.vec() +
+                m_real.vec().cross(m_dual.vec()));
 
     return p;
 }
 
-template<typename T>
+template <typename T>
 Eigen::Matrix<T, 3, 1>
-DualQuaternion<T>::transformVector(const Eigen::Matrix<T, 3, 1>& vector) const
-{
-    DualQuaternion<T> dq = (*this)
-                           * DualQuaternion<T>(Eigen::Quaternion<T>(1, 0, 0, 0),
-                                               Eigen::Quaternion<T>(0, vector(0,0), vector(1,0), vector(2,0)))
-                           * conjugate();
+DualQuaternion<T>::transformVector(const Eigen::Matrix<T, 3, 1>& vector) const {
+    DualQuaternion<T> dq =
+        (*this) *
+        DualQuaternion<T>(
+            Eigen::Quaternion<T>(1, 0, 0, 0),
+            Eigen::Quaternion<T>(0, vector(0, 0), vector(1, 0), vector(2, 0))) *
+        conjugate();
 
     return Eigen::Matrix<T, 3, 1>(dq.m_dual.x(), dq.m_dual.y(), dq.m_dual.z());
 }
 
-template<typename T>
-Eigen::Quaternion<T>
-DualQuaternion<T>::real(void) const
-{
+template <typename T> Eigen::Quaternion<T> DualQuaternion<T>::real(void) const {
     return m_real;
 }
 
-template<typename T>
-Eigen::Quaternion<T>
-DualQuaternion<T>::rotation(void) const
-{
+template <typename T>
+Eigen::Quaternion<T> DualQuaternion<T>::rotation(void) const {
     return m_real;
 }
 
-template<typename T>
-Eigen::Matrix<T, 3, 1>
-DualQuaternion<T>::translation(void) const
-{
+template <typename T>
+Eigen::Matrix<T, 3, 1> DualQuaternion<T>::translation(void) const {
     Eigen::Quaternion<T> t(2.0 * (m_dual * m_real.conjugate()).coeffs());
 
     Eigen::Matrix<T, 3, 1> tvec;
@@ -265,110 +228,93 @@ DualQuaternion<T>::translation(void) const
     return tvec;
 }
 
-template<typename T>
-Eigen::Quaternion<T>
-DualQuaternion<T>::translationQuaternion(void) const
-{
+template <typename T>
+Eigen::Quaternion<T> DualQuaternion<T>::translationQuaternion(void) const {
     Eigen::Quaternion<T> t(2.0 * (m_dual * m_real.conjugate()).coeffs());
 
     return t;
 }
 
-template<typename T>
-Eigen::Matrix<T, 4, 4>
-DualQuaternion<T>::toMatrix(void) const
-{
+template <typename T>
+Eigen::Matrix<T, 4, 4> DualQuaternion<T>::toMatrix(void) const {
     Eigen::Matrix<T, 4, 4> H = Eigen::Matrix<T, 4, 4>::Identity();
 
-    H.block(0, 0, 3, 3)= m_real.toRotationMatrix();
+    H.block(0, 0, 3, 3) = m_real.toRotationMatrix();
 
     Eigen::Quaternion<T> t(2.0 * (m_dual * m_real.conjugate()).coeffs());
-    H(0,3) = t.x();
-    H(1,3) = t.y();
-    H(2,3) = t.z();
+    H(0, 3) = t.x();
+    H(1, 3) = t.y();
+    H(2, 3) = t.z();
 
     return H;
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::zeros(void)
-{
+template <typename T> DualQuaternion<T> DualQuaternion<T>::zeros(void) {
     return DualQuaternion<T>(Eigen::Quaternion<T>(T(0), T(0), T(0), T(0)),
                              Eigen::Quaternion<T>(T(0), T(0), T(0), T(0)));
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::operator*(T scale) const
-{
+template <typename T>
+DualQuaternion<T> DualQuaternion<T>::operator*(T scale) const {
     return DualQuaternion<T>(Eigen::Quaternion<T>(scale * m_real.coeffs()),
                              Eigen::Quaternion<T>(scale * m_dual.coeffs()));
 }
 
-template<typename T>
-DualQuaternion<T>
-DualQuaternion<T>::operator*(const DualQuaternion<T>& other) const
-{
-    return DualQuaternion<T>(m_real * other.m_real,
-                             Eigen::Quaternion<T>((m_real * other.m_dual).coeffs() +
-                                                  (m_dual * other.m_real).coeffs()));
+template <typename T>
+DualQuaternion<T> DualQuaternion<T>::
+operator*(const DualQuaternion<T>& other) const {
+    return DualQuaternion<T>(
+        m_real * other.m_real,
+        Eigen::Quaternion<T>((m_real * other.m_dual).coeffs() +
+                             (m_dual * other.m_real).coeffs()));
 }
 
-template<typename T>
-DualQuaternion<T>
-operator+(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2)
-{
-    return DualQuaternion<T>(Eigen::Quaternion<T>(dq1.m_real.coeffs() + dq2.m_real.coeffs()),
-                             Eigen::Quaternion<T>(dq1.m_dual.coeffs() + dq2.m_dual.coeffs()));
+template <typename T>
+DualQuaternion<T> operator+(const DualQuaternion<T>& dq1,
+                            const DualQuaternion<T>& dq2) {
+    return DualQuaternion<T>(
+        Eigen::Quaternion<T>(dq1.m_real.coeffs() + dq2.m_real.coeffs()),
+        Eigen::Quaternion<T>(dq1.m_dual.coeffs() + dq2.m_dual.coeffs()));
 }
 
-template<typename T>
-DualQuaternion<T>
-operator-(const DualQuaternion<T>& dq1, const DualQuaternion<T>& dq2)
-{
-    return DualQuaternion<T>(Eigen::Quaternion<T>(dq1.m_real.coeffs() - dq2.m_real.coeffs()),
-                             Eigen::Quaternion<T>(dq1.m_dual.coeffs() - dq2.m_dual.coeffs()));
+template <typename T>
+DualQuaternion<T> operator-(const DualQuaternion<T>& dq1,
+                            const DualQuaternion<T>& dq2) {
+    return DualQuaternion<T>(
+        Eigen::Quaternion<T>(dq1.m_real.coeffs() - dq2.m_real.coeffs()),
+        Eigen::Quaternion<T>(dq1.m_dual.coeffs() - dq2.m_dual.coeffs()));
 }
 
-template<typename T>
-DualQuaternion<T>
-operator*(T scale, const DualQuaternion<T>& dq)
-{
+template <typename T>
+DualQuaternion<T> operator*(T scale, const DualQuaternion<T>& dq) {
     return DualQuaternion<T>(Eigen::Quaternion<T>(scale * dq.real().coeffs()),
                              Eigen::Quaternion<T>(scale * dq.dual().coeffs()));
 }
 
-
-template<typename T>
-std::ostream& operator << (std::ostream & out, const DualQuaternion<T> & dq)
-{
-    out << dq.m_real.w() << " " << dq.m_real.x() << " " << dq.m_real.y() << " " << dq.m_real.z() << " "
-        << dq.m_dual.w() << " " << dq.m_dual.x() << " " << dq.m_dual.y() << " " << dq.m_dual.z() << std::endl; 
-    return out; 
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const DualQuaternion<T>& dq) {
+    out << dq.m_real.w() << " " << dq.m_real.x() << " " << dq.m_real.y() << " "
+        << dq.m_real.z() << " " << dq.m_dual.w() << " " << dq.m_dual.x() << " "
+        << dq.m_dual.y() << " " << dq.m_dual.z() << std::endl;
+    return out;
 }
 
-template<typename T>
+template <typename T>
 DualQuaternion<T>
-//exp(Eigen::Quaternion<T> _real, Eigen::Quaternion<T> _dual);
-expdq(const std::pair<Eigen::Quaternion<T>, Eigen::Quaternion<T> > & v8x1 )
-{
+    // exp(Eigen::Quaternion<T> _real, Eigen::Quaternion<T> _dual);
+    expdq(const std::pair<Eigen::Quaternion<T>, Eigen::Quaternion<T>>& v8x1) {
     Eigen::Quaternion<T> real = expq(v8x1.first);
     Eigen::Quaternion<T> dual = real * v8x1.second;
     return DualQuaternion<T>(real, dual);
 }
 
-template<typename T>
-std::pair<Eigen::Quaternion<T>, Eigen::Quaternion<T> >
-logdq(const DualQuaternion<T> & dq)
-{
+template <typename T>
+std::pair<Eigen::Quaternion<T>, Eigen::Quaternion<T>>
+logdq(const DualQuaternion<T>& dq) {
     Eigen::Quaternion<T> real = logq(dq.real());
     Eigen::Quaternion<T> dual = dq.real().inverse() * dq.dual();
     return std::make_pair(real, dual);
 }
-
 }
-
-
 
 #endif

--- a/src/camodocal/calib/HandEyeCalibration.cc
+++ b/src/camodocal/calib/HandEyeCalibration.cc
@@ -1,27 +1,25 @@
 #include "camodocal/calib/HandEyeCalibration.h"
 
-#include <iostream>
 #include <boost/throw_exception.hpp>
+#include <iostream>
 
 #include <ceres/ceres.h>
-#include "camodocal/calib/DualQuaternion.h"
 #include "camodocal/EigenUtils.h"
+#include "camodocal/calib/DualQuaternion.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-/// @todo there may be an alignment issue, see http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
-class PoseError
-{
-public:
-    PoseError(Eigen::Vector3d r1, Eigen::Vector3d t1,
-              Eigen::Vector3d r2, Eigen::Vector3d t2)
-        : m_rvec1(r1), m_rvec2(r2), m_tvec1(t1), m_tvec2(t2)
-    {}
+/// @todo there may be an alignment issue, see
+/// http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
+class PoseError {
+  public:
+    PoseError(Eigen::Vector3d r1, Eigen::Vector3d t1, Eigen::Vector3d r2,
+              Eigen::Vector3d t2)
+        : m_rvec1(r1), m_rvec2(r2), m_tvec1(t1), m_tvec2(t2) {}
 
-    template<typename T>
-    bool operator() (const T* const q4x1, const T* const t3x1, T* residual) const
-    {
+    template <typename T>
+    bool operator()(const T* const q4x1, const T* const t3x1,
+                    T* residual) const {
         Eigen::Quaternion<T> q(q4x1[0], q4x1[1], q4x1[2], q4x1[3]);
         Eigen::Matrix<T, 3, 1> t;
         t << t3x1[0], t3x1[1], t3x1[2];
@@ -43,51 +41,41 @@ public:
         return true;
     }
 
-private:
+  private:
     Eigen::Vector3d m_rvec1, m_rvec2, m_tvec1, m_tvec2;
-public:
-    /// @see http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
+
+  public:
+    /// @see
+    /// http://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 bool HandEyeCalibration::mVerbose = true;
 
-HandEyeCalibration::HandEyeCalibration()
-{
+HandEyeCalibration::HandEyeCalibration() {}
 
-}
-
-void
-HandEyeCalibration::setVerbose(bool on)
-{
-    mVerbose = on;
-}
-
+void HandEyeCalibration::setVerbose(bool on) { mVerbose = on; }
 
 /// Reorganize data to prepare for running SVD
 /// Daniilidis 1999 Section 6, Equations (31) and (33), on page 291
 template <typename T>
 static Eigen::MatrixXd ScrewToStransposeBlockofT(
-                                                    const Eigen::Matrix<T, 3, 1>& a,
-                                                    const Eigen::Matrix<T, 3, 1>& a_prime,
-                                                    const Eigen::Matrix<T, 3, 1>& b,
-                                                    const Eigen::Matrix<T, 3, 1>& b_prime
-                                                    )
-{
-        Eigen::MatrixXd Stranspose(6,8);
-        Stranspose.setZero();
+    const Eigen::Matrix<T, 3, 1>& a, const Eigen::Matrix<T, 3, 1>& a_prime,
+    const Eigen::Matrix<T, 3, 1>& b, const Eigen::Matrix<T, 3, 1>& b_prime) {
+    Eigen::MatrixXd Stranspose(6, 8);
+    Stranspose.setZero();
 
-        typedef Eigen::Matrix<T, 3, 1> VecT;
-        auto skew_a_plus_b = skew(VecT(a + b));
-        auto a_minus_b = a - b;
-        Stranspose.block<3,1>( 0, 0) = a_minus_b;
-        Stranspose.block<3,3>( 0, 1) = skew_a_plus_b;
-        Stranspose.block<3,1>( 3, 0) = a_prime - b_prime;
-        Stranspose.block<3,3>( 3, 1) = skew(VecT(a_prime + b_prime));
-        Stranspose.block<3,1>( 3, 4) = a_minus_b;
-        Stranspose.block<3,3>( 3, 5) = skew_a_plus_b;
+    typedef Eigen::Matrix<T, 3, 1> VecT;
+    auto skew_a_plus_b = skew(VecT(a + b));
+    auto a_minus_b = a - b;
+    Stranspose.block<3, 1>(0, 0) = a_minus_b;
+    Stranspose.block<3, 3>(0, 1) = skew_a_plus_b;
+    Stranspose.block<3, 1>(3, 0) = a_prime - b_prime;
+    Stranspose.block<3, 3>(3, 1) = skew(VecT(a_prime + b_prime));
+    Stranspose.block<3, 1>(3, 4) = a_minus_b;
+    Stranspose.block<3, 3>(3, 5) = skew_a_plus_b;
 
-        return Stranspose;
+    return Stranspose;
 }
 
 /// Reorganize data to prepare for running SVD
@@ -95,60 +83,57 @@ static Eigen::MatrixXd ScrewToStransposeBlockofT(
 // @pre no zero rotations, thus (rvec1.norm() != 0 && rvec2.norm() != 0) == true
 template <typename T>
 static Eigen::MatrixXd AxisAngleToSTransposeBlockOfT(
-                                                    const Eigen::Matrix<T, 3, 1>& rvec1,
-                                                    const Eigen::Matrix<T, 3, 1>& tvec1,
-                                                    const Eigen::Matrix<T, 3, 1>& rvec2,
-                                                    const Eigen::Matrix<T, 3, 1>& tvec2
-                                                    )
-{
-        double theta1, d1;
-        Eigen::Vector3d l1, m1;
-        AngleAxisAndTranslationToScrew(rvec1, tvec1, theta1, d1, l1, m1);
+    const Eigen::Matrix<T, 3, 1>& rvec1, const Eigen::Matrix<T, 3, 1>& tvec1,
+    const Eigen::Matrix<T, 3, 1>& rvec2, const Eigen::Matrix<T, 3, 1>& tvec2) {
+    double theta1, d1;
+    Eigen::Vector3d l1, m1;
+    AngleAxisAndTranslationToScrew(rvec1, tvec1, theta1, d1, l1, m1);
 
-        double theta2, d2;
-        Eigen::Vector3d l2, m2;
-        AngleAxisAndTranslationToScrew(rvec2, tvec2, theta2, d2, l2, m2);
+    double theta2, d2;
+    Eigen::Vector3d l2, m2;
+    AngleAxisAndTranslationToScrew(rvec2, tvec2, theta2, d2, l2, m2);
 
-        Eigen::Vector3d a = l1;
-        Eigen::Vector3d a_prime = m1;
-        Eigen::Vector3d b = l2;
-        Eigen::Vector3d b_prime = m2;
+    Eigen::Vector3d a = l1;
+    Eigen::Vector3d a_prime = m1;
+    Eigen::Vector3d b = l2;
+    Eigen::Vector3d b_prime = m2;
 
-        return ScrewToStransposeBlockofT(a,a_prime,b,b_prime);
+    return ScrewToStransposeBlockofT(a, a_prime, b, b_prime);
 }
 
-  // docs in header
-void
-HandEyeCalibration::estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                         Eigen::Matrix4d& H_12,
-                                         bool planarMotion)
-{
+// docs in header
+void HandEyeCalibration::estimateHandEyeScrew(
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+    Eigen::Matrix4d& H_12, bool planarMotion) {
     int motionCount = rvecs1.size();
     Eigen::MatrixXd T(motionCount * 6, 8);
     T.setZero();
 
-    for (size_t i = 0; i < motionCount; ++i)
-    {
+    for (size_t i = 0; i < motionCount; ++i) {
         const Eigen::Vector3d& rvec1 = rvecs1.at(i);
         const Eigen::Vector3d& tvec1 = tvecs1.at(i);
         const Eigen::Vector3d& rvec2 = rvecs2.at(i);
         const Eigen::Vector3d& tvec2 = tvecs2.at(i);
 
         // Skip cases with zero rotation
-        if (rvec1.norm() == 0 || rvec2.norm() == 0) continue;
+        if (rvec1.norm() == 0 || rvec2.norm() == 0)
+            continue;
 
-        T.block<6,8>(i * 6, 0) = AxisAngleToSTransposeBlockOfT(rvec1,tvec1,rvec2,tvec2);
+        T.block<6, 8>(i * 6, 0) =
+            AxisAngleToSTransposeBlockOfT(rvec1, tvec1, rvec2, tvec2);
     }
 
-    auto dq = estimateHandEyeScrewInitial(T,planarMotion);
-
+    auto dq = estimateHandEyeScrewInitial(T, planarMotion);
 
     H_12 = dq.toMatrix();
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << "# INFO: Before refinement: H_12 = " << std::endl;
         std::cout << H_12 << std::endl;
     }
@@ -156,48 +141,45 @@ HandEyeCalibration::estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eige
     estimateHandEyeScrewRefine(dq, rvecs1, tvecs1, rvecs2, tvecs2);
 
     H_12 = dq.toMatrix();
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << "# INFO: After refinement: H_12 = " << std::endl;
         std::cout << H_12 << std::endl;
     }
-
-
 }
 
 // docs in header
-void
-HandEyeCalibration::estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                         Eigen::Matrix4d& H_12,
-                                         ceres::Solver::Summary& summary,
-                                         bool planarMotion)
-{
+void HandEyeCalibration::estimateHandEyeScrew(
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+    Eigen::Matrix4d& H_12, ceres::Solver::Summary& summary, bool planarMotion) {
     int motionCount = rvecs1.size();
     Eigen::MatrixXd T(motionCount * 6, 8);
     T.setZero();
 
-    for (size_t i = 0; i < motionCount; ++i)
-    {
+    for (size_t i = 0; i < motionCount; ++i) {
         const Eigen::Vector3d& rvec1 = rvecs1.at(i);
         const Eigen::Vector3d& tvec1 = tvecs1.at(i);
         const Eigen::Vector3d& rvec2 = rvecs2.at(i);
         const Eigen::Vector3d& tvec2 = tvecs2.at(i);
 
         // Skip cases with zero rotation
-        if (rvec1.norm() == 0 || rvec2.norm() == 0) continue;
+        if (rvec1.norm() == 0 || rvec2.norm() == 0)
+            continue;
 
-        T.block<6,8>(i * 6, 0) = AxisAngleToSTransposeBlockOfT(rvec1,tvec1,rvec2,tvec2);
+        T.block<6, 8>(i * 6, 0) =
+            AxisAngleToSTransposeBlockOfT(rvec1, tvec1, rvec2, tvec2);
     }
 
-    auto dq = estimateHandEyeScrewInitial(T,planarMotion);
-
+    auto dq = estimateHandEyeScrewInitial(T, planarMotion);
 
     H_12 = dq.toMatrix();
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << "# INFO: Before refinement: H_12 = " << std::endl;
         std::cout << H_12 << std::endl;
     }
@@ -205,103 +187,91 @@ HandEyeCalibration::estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eige
     estimateHandEyeScrewRefine(dq, rvecs1, tvecs1, rvecs2, tvecs2, summary);
 
     H_12 = dq.toMatrix();
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << "# INFO: After refinement: H_12 = " << std::endl;
         std::cout << H_12 << std::endl;
     }
-
 }
-
 
 // docs in header
 DualQuaterniond
 HandEyeCalibration::estimateHandEyeScrewInitial(Eigen::MatrixXd& T,
-                                         bool planarMotion)
-{
-
+                                                bool planarMotion) {
 
     // dq(r1, t1) = dq * dq(r2, t2) * dq.inv
-    Eigen::JacobiSVD<Eigen::MatrixXd> svd(T, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(T, Eigen::ComputeFullU |
+                                                 Eigen::ComputeFullV);
 
     // v7 and v8 span the null space of T, v6 may also be one
     // if rank = 5.
-    Eigen::Matrix<double, 8, 1> v6 = svd.matrixV().block<8,1>(0, 5);
-    Eigen::Matrix<double, 8, 1> v7 = svd.matrixV().block<8,1>(0,6);
-    Eigen::Matrix<double, 8, 1> v8 = svd.matrixV().block<8,1>(0,7);
+    Eigen::Matrix<double, 8, 1> v6 = svd.matrixV().block<8, 1>(0, 5);
+    Eigen::Matrix<double, 8, 1> v7 = svd.matrixV().block<8, 1>(0, 6);
+    Eigen::Matrix<double, 8, 1> v8 = svd.matrixV().block<8, 1>(0, 7);
 
     // if rank = 5
     if (planarMotion) //(rank == 5)
     {
-        if (mVerbose)
-        {
-            std::cout << "# INFO: No unique solution, returned an arbitrary one. " << std::endl;
+        if (mVerbose) {
+            std::cout
+                << "# INFO: No unique solution, returned an arbitrary one. "
+                << std::endl;
         }
 
         v7 += v6;
     }
 
-    Eigen::Vector4d u1 = v7.block<4,1>(0,0);
-    Eigen::Vector4d v1 = v7.block<4,1>(4,0);
-    Eigen::Vector4d u2 = v8.block<4,1>(0,0);
-    Eigen::Vector4d v2 = v8.block<4,1>(4,0);
+    Eigen::Vector4d u1 = v7.block<4, 1>(0, 0);
+    Eigen::Vector4d v1 = v7.block<4, 1>(4, 0);
+    Eigen::Vector4d u2 = v8.block<4, 1>(0, 0);
+    Eigen::Vector4d v2 = v8.block<4, 1>(4, 0);
 
     double lambda1 = 0;
     double lambda2 = 0.0;
 
-    if (u1.dot(v1) == 0.0)
-    {
+    if (u1.dot(v1) == 0.0) {
         std::swap(u1, u2);
         std::swap(v1, v2);
     }
-    if (u1.dot(v1) != 0.0)
-    {
+    if (u1.dot(v1) != 0.0) {
         double s[2];
-        solveQuadraticEquation(u1.dot(v1), u1.dot(v2) + u2.dot(v1), u2.dot(v2), s[0], s[1]);
+        solveQuadraticEquation(u1.dot(v1), u1.dot(v2) + u2.dot(v1), u2.dot(v2),
+                               s[0], s[1]);
 
         // find better solution for s
         double t[2];
-        for (int i = 0; i < 2; ++i)
-        {
-            t[i] = s[i] * s[i] * u1.dot(u1) + 2 * s[i] * u1.dot(u2) + u2.dot(u2);
+        for (int i = 0; i < 2; ++i) {
+            t[i] =
+                s[i] * s[i] * u1.dot(u1) + 2 * s[i] * u1.dot(u2) + u2.dot(u2);
         }
 
         int idx;
-        if (t[0] > t[1])
-        {
+        if (t[0] > t[1]) {
             idx = 0;
-        }
-        else
-        {
+        } else {
             idx = 1;
         }
 
-        double discriminant = 4.0 * square(u1.dot(u2)) - 4.0 * (u1.dot(u1) * u2.dot(u2));
-        if (discriminant == 0.0 && mVerbose)
-        {
-//            std::cout << "# INFO: Noise-free case" << std::endl;
+        double discriminant =
+            4.0 * square(u1.dot(u2)) - 4.0 * (u1.dot(u1) * u2.dot(u2));
+        if (discriminant == 0.0 && mVerbose) {
+            //            std::cout << "# INFO: Noise-free case" << std::endl;
         }
 
         lambda2 = sqrt(1.0 / t[idx]);
         lambda1 = s[idx] * lambda2;
-    }
-    else
-    {
-        if (u1.norm() == 0 && u2.norm() > 0)
-        {
+    } else {
+        if (u1.norm() == 0 && u2.norm() > 0) {
             lambda1 = 0;
             lambda2 = 1.0 / u2.norm();
-        }
-        else if (u2.norm() == 0 && u1.norm() > 0)
-        {
+        } else if (u2.norm() == 0 && u1.norm() > 0) {
             lambda1 = 1.0 / u1.norm();
             lambda2 = 0;
-        }
-        else
-        {
-           std::ostringstream ss;
+        } else {
+            std::ostringstream ss;
 
-            ss << "camodocal::HandEyeCalibration error: normalization could not be handled. Your rotations and translations are probably either not aligned or not passed in properly.";
+            ss << "camodocal::HandEyeCalibration error: normalization could "
+                  "not be handled. Your rotations and translations are "
+                  "probably either not aligned or not passed in properly.";
             ss << "u1:" << std::endl;
             ss << u1 << std::endl;
             ss << "v1:" << std::endl;
@@ -310,7 +280,9 @@ HandEyeCalibration::estimateHandEyeScrewInitial(Eigen::MatrixXd& T,
             ss << u2 << std::endl;
             ss << "v2:" << std::endl;
             ss << v2 << std::endl;
-            ss << "Not handled yet. Your rotations and translations are probably either not aligned or not passed in properly." << std::endl;
+            ss << "Not handled yet. Your rotations and translations are "
+                  "probably either not aligned or not passed in properly."
+               << std::endl;
 
             BOOST_THROW_EXCEPTION(std::runtime_error(ss.str()));
         }
@@ -321,19 +293,18 @@ HandEyeCalibration::estimateHandEyeScrewInitial(Eigen::MatrixXd& T,
     Eigen::Vector4d q_prime_coeffs = lambda1 * v1 + lambda2 * v2;
 
     Eigen::Quaterniond q(q_coeffs(0), q_coeffs(1), q_coeffs(2), q_coeffs(3));
-    Eigen::Quaterniond d(q_prime_coeffs(0), q_prime_coeffs(1), q_prime_coeffs(2), q_prime_coeffs(3));
+    Eigen::Quaterniond d(q_prime_coeffs(0), q_prime_coeffs(1),
+                         q_prime_coeffs(2), q_prime_coeffs(3));
 
     return DualQuaterniond(q, d);
 }
 
 // docs in header
-bool
-HandEyeCalibration::solveQuadraticEquation(double a, double b, double c, double& x1, double& x2)
-{
+bool HandEyeCalibration::solveQuadraticEquation(double a, double b, double c,
+                                                double& x1, double& x2) {
     double delta2 = b * b - 4.0 * a * c;
 
-    if (delta2 < 0.0)
-    {
+    if (delta2 < 0.0) {
         return false;
     }
 
@@ -346,21 +317,23 @@ HandEyeCalibration::solveQuadraticEquation(double a, double b, double c, double&
 }
 
 // docs in header
-void
-HandEyeCalibration::estimateHandEyeScrewRefine(DualQuaterniond& dq,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                               ceres::Solver::Summary& summary)
-{
+void HandEyeCalibration::estimateHandEyeScrewRefine(
+    DualQuaterniond& dq,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+    ceres::Solver::Summary& summary) {
     Eigen::Matrix4d H = dq.toMatrix();
     double p[7] = {dq.real().w(), dq.real().x(), dq.real().y(), dq.real().z(),
-                   H(0, 3), H(1, 3), H(2, 3)};
+                   H(0, 3),       H(1, 3),       H(2, 3)};
 
     ceres::Problem problem;
-    for (size_t i = 0; i < rvecs1.size(); i++)
-    {
+    for (size_t i = 0; i < rvecs1.size(); i++) {
         // ceres deletes the objects allocated here for the user
         ceres::CostFunction* costFunction =
             new ceres::AutoDiffCostFunction<PoseError, 1, 4, 3>(
@@ -383,8 +356,7 @@ HandEyeCalibration::estimateHandEyeScrewRefine(DualQuaterniond& dq,
     // ceres::Solver::Summary summary;
     ceres::Solve(options, &problem, &summary);
 
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << summary.BriefReport() << std::endl;
     }
 
@@ -392,24 +364,25 @@ HandEyeCalibration::estimateHandEyeScrewRefine(DualQuaterniond& dq,
     Eigen::Vector3d t;
     t << p[4], p[5], p[6];
     dq = DualQuaterniond(q, t);
-
 }
 
-void
-HandEyeCalibration::estimateHandEyeScrewRefine(DualQuaterniond& dq,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                               const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2)
-{
+void HandEyeCalibration::estimateHandEyeScrewRefine(
+    DualQuaterniond& dq,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+    const std::vector<Eigen::Vector3d,
+                      Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2) {
     Eigen::Matrix4d H = dq.toMatrix();
     double p[7] = {dq.real().w(), dq.real().x(), dq.real().y(), dq.real().z(),
-                   H(0, 3), H(1, 3), H(2, 3)};
+                   H(0, 3),       H(1, 3),       H(2, 3)};
     ceres::Solver::Summary summary;
 
     ceres::Problem problem;
-    for (size_t i = 0; i < rvecs1.size(); i++)
-    {
+    for (size_t i = 0; i < rvecs1.size(); i++) {
         // ceres deletes the objects allocated here for the user
         ceres::CostFunction* costFunction =
             new ceres::AutoDiffCostFunction<PoseError, 1, 4, 3>(
@@ -432,8 +405,7 @@ HandEyeCalibration::estimateHandEyeScrewRefine(DualQuaterniond& dq,
     // ceres::Solver::Summary summary;
     ceres::Solve(options, &problem, &summary);
 
-    if (mVerbose)
-    {
+    if (mVerbose) {
         std::cout << summary.BriefReport() << std::endl;
     }
 

--- a/src/camodocal/calib/HandEyeCalibration.h
+++ b/src/camodocal/calib/HandEyeCalibration.h
@@ -6,96 +6,134 @@
 #include <ceres/ceres.h>
 #include "DualQuaternion.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-/// @brief Implements Hand Eye Calibration which determines an unknown 3d transform using two stacks of known transforms.
+/// @brief Implements Hand Eye Calibration which determines an unknown 3d
+/// transform using two stacks of known transforms.
 ///
-/// @see <a href="https://robotics.stackexchange.com/questions/7163/hand-eye-calibration">StackOverflow Explanation of Hand Eye Calibration with CamOdoCal</a>
+/// @see <a
+/// href="https://robotics.stackexchange.com/questions/7163/hand-eye-calibration">StackOverflow
+/// Explanation of Hand Eye Calibration with CamOdoCal</a>
 ///
-///  Daniilidis, Konstantinos. "Hand-eye calibration using dual quaternions." The International Journal of Robotics Research 18.3 (1999): 286-298.
-/// @see <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.136.5873&rank=1">Daniilidis 1999</a>
+///  Daniilidis, Konstantinos. "Hand-eye calibration using dual quaternions."
+///  The International Journal of Robotics Research 18.3 (1999): 286-298.
+/// @see <a
+/// href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.136.5873&rank=1">Daniilidis
+/// 1999</a>
 ///
 
-class HandEyeCalibration
-{
-public:
+class HandEyeCalibration {
+  public:
     HandEyeCalibration();
 
-    
-    /// @brief Estimate an unknown rigid transform using two matching series of changing known rigid transforms.
+    /// @brief Estimate an unknown rigid transform using two matching series of
+    /// changing known rigid transforms.
     ///
-    /// Given two vectors with N equivalent but changing transforms in each index i,
+    /// Given two vectors with N equivalent but changing transforms in each
+    /// index i,
     /// estimate the 4x4 rigid Homogeneous transformation matrix between them.
     ///
     /// Each known transform can be from the first to the current T_0_i,
-    /// or from the previous to the current T_(i-1)_i, but they must be consistent.
+    /// or from the previous to the current T_(i-1)_i, but they must be
+    /// consistent.
     ///
     ///
-    /// 1. Each measurement taken at a different time, position, and orientation narrows down the possible transforms that can represent the unknown X
+    /// 1. Each measurement taken at a different time, position, and orientation
+    /// narrows down the possible transforms that can represent the unknown X
     ///
-    /// 2. Record a list of many transforms A and B taken between different time steps, or relative to the first time step
-    ///      - Rotations are in AxisAngle = UnitAxis*Angle format, or [x_axis,y_axis,z_axis]*𝜃_angle
+    /// 2. Record a list of many transforms A and B taken between different time
+    /// steps, or relative to the first time step
+    ///      - Rotations are in AxisAngle = UnitAxis*Angle format, or
+    ///      [x_axis,y_axis,z_axis]*𝜃_angle
     ///         - ||UnitAxis||=1
     ///         - || AxisAngle || = 𝜃_angle
     ///      - Translations are in the normal [x,y,z] format
     /// 3. Pass both vectors into EstimateHandEyeScrew()
     /// 4. Returns X in the form of a 4x4 transform estimate
     ///
-    /// @param rvecs1 vector of the unit axis and angle for the first transform set with size N
-    /// @param tvecs1 vector of the translation for the first transform set with size N
-    /// @param rvecs2 vector of size N with each element containing the unit axis and angle for the second transform with size N
-    /// @param tvecs2 vector of the translation for the second transform with size N
+    /// @param rvecs1 vector of the unit axis and angle for the first transform
+    /// set with size N
+    /// @param tvecs1 vector of the translation for the first transform set with
+    /// size N
+    /// @param rvecs2 vector of size N with each element containing the unit
+    /// axis and angle for the second transform with size N
+    /// @param tvecs2 vector of the translation for the second transform with
+    /// size N
     ///
     /// @pre all sets of parameters must have the same number of elements
-    /* static void estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1, */
-    /*                                  const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1, */
-    /*                                  const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2, */
-    /*                                  const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2, */
-    /*                                  Eigen::Matrix4d& H_12, bool planarMotion = false); */
+    /* static void estimateHandEyeScrew(const std::vector<Eigen::Vector3d,
+     * Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1, */
+    /*                                  const std::vector<Eigen::Vector3d,
+     * Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1, */
+    /*                                  const std::vector<Eigen::Vector3d,
+     * Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2, */
+    /*                                  const std::vector<Eigen::Vector3d,
+     * Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2, */
+    /*                                  Eigen::Matrix4d& H_12, bool planarMotion
+     * = false); */
 
-    static void estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                   Eigen::Matrix4d& H_12,
-                                   bool planarMotion = false);
+    static void estimateHandEyeScrew(
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+        Eigen::Matrix4d& H_12, bool planarMotion = false);
 
-
-    static void estimateHandEyeScrew(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                   const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                   Eigen::Matrix4d& H_12,
-                                   ceres::Solver::Summary& summary,
-                                   bool planarMotion = false);
+    static void estimateHandEyeScrew(
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+        Eigen::Matrix4d& H_12, ceres::Solver::Summary& summary,
+        bool planarMotion = false);
 
     static void setVerbose(bool on = true);
 
-private:
+  private:
     /// @brief solve ax^2 + bx + c = 0
-    static bool solveQuadraticEquation(double a, double b, double c, double& x1, double& x2);
+    static bool solveQuadraticEquation(double a, double b, double c, double& x1,
+                                       double& x2);
 
-    /// @brief Initial hand-eye screw estimate using fast but coarse Eigen::JacobiSVD
-    static DualQuaterniond estimateHandEyeScrewInitial(Eigen::MatrixXd& T,bool planarMotion);
+    /// @brief Initial hand-eye screw estimate using fast but coarse
+    /// Eigen::JacobiSVD
+    static DualQuaterniond estimateHandEyeScrewInitial(Eigen::MatrixXd& T,
+                                                       bool planarMotion);
 
-    /// @brief Refine hand-eye screw estimate using initial coarse estimate and Ceres Solver Library.
-    static void estimateHandEyeScrewRefine(DualQuaterniond& dq,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                         const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2);
+    /// @brief Refine hand-eye screw estimate using initial coarse estimate and
+    /// Ceres Solver Library.
+    static void estimateHandEyeScrewRefine(
+        DualQuaterniond& dq,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2);
 
-    static void estimateHandEyeScrewRefine(DualQuaterniond& dq,
-                                           const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs1,
-                                           const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs1,
-                                           const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& rvecs2,
-                                           const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& tvecs2,
-                                           ceres::Solver::Summary& summary);
+    static void estimateHandEyeScrewRefine(
+        DualQuaterniond& dq,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs1,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& rvecs2,
+        const std::vector<Eigen::Vector3d,
+                          Eigen::aligned_allocator<Eigen::Vector3d>>& tvecs2,
+        ceres::Solver::Summary& summary);
 
     static bool mVerbose;
 };
-
 }
 
 #endif

--- a/src/camodocal/calib/HandEyeCalibration_test.cc
+++ b/src/camodocal/calib/HandEyeCalibration_test.cc
@@ -1,29 +1,29 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
-#include "camodocal/calib/HandEyeCalibration.h"
 #include "../gpl/gpl.h"
 #include "camodocal/EigenUtils.h"
+#include "camodocal/calib/HandEyeCalibration.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-TEST(HandEyeCalibration, FullMotion)
-{
+TEST(HandEyeCalibration, FullMotion) {
     HandEyeCalibration::setVerbose(false);
 
     Eigen::Matrix4d H_12_expected = Eigen::Matrix4d::Identity();
-    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized()).toRotationMatrix();
-    H_12_expected.block<3,1>(0,3) << 0.5, 0.6, 0.7;
+    H_12_expected.block<3, 3>(0, 0) =
+        Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized())
+            .toRotationMatrix();
+    H_12_expected.block<3, 1>(0, 3) << 0.5, 0.6, 0.7;
 
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > rvecs1, tvecs1, rvecs2, tvecs2;
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>>
+        rvecs1, tvecs1, rvecs2, tvecs2;
 
     int motionCount = 2;
-    for (int i = 0; i < motionCount; ++i)
-    {
+    for (int i = 0; i < motionCount; ++i) {
         double droll = d2r(random(-10.0, 10.0));
-        double dpitch =  d2r(random(-10.0, 10.0));
-        double dyaw =  d2r(random(-10.0, 10.0));
+        double dpitch = d2r(random(-10.0, 10.0));
+        double dyaw = d2r(random(-10.0, 10.0));
         double dx = random(-1.0, 1.0);
         double dy = random(-1.0, 1.0);
         double dz = random(-1.0, 1.0);
@@ -34,23 +34,24 @@ TEST(HandEyeCalibration, FullMotion)
             Eigen::AngleAxisd(droll, Eigen::Vector3d::UnitX());
 
         Eigen::Matrix4d H = Eigen::Matrix4d::Identity();
-        H.block<3,3>(0,0) = R;
-        H.block<3,1>(0,3) << dx, dy, dz;
+        H.block<3, 3>(0, 0) = R;
+        H.block<3, 1>(0, 3) << dx, dy, dz;
 
         Eigen::Matrix4d H_ = H.inverse();
         H = H_;
 
         Eigen::Vector3d rvec1, tvec1, rvec2, tvec2;
 
-        Eigen::AngleAxisd angleAxis1((H_12_expected * H * H_12_expected.inverse()).block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis1(
+            (H_12_expected * H * H_12_expected.inverse()).block<3, 3>(0, 0));
         rvec1 = angleAxis1.angle() * angleAxis1.axis();
 
-        tvec1 = (H_12_expected * H * H_12_expected.inverse()).block<3,1>(0,3);
+        tvec1 = (H_12_expected * H * H_12_expected.inverse()).block<3, 1>(0, 3);
 
-        Eigen::AngleAxisd angleAxis2(H.block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis2(H.block<3, 3>(0, 0));
         rvec2 = angleAxis2.angle() * angleAxis2.axis();
 
-        tvec2 = H.block<3,1>(0,3);
+        tvec2 = H.block<3, 1>(0, 3);
 
         rvecs1.push_back(rvec1);
         tvecs1.push_back(tvec1);
@@ -59,35 +60,36 @@ TEST(HandEyeCalibration, FullMotion)
     }
 
     Eigen::Matrix4d H_12;
-    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2, H_12);
+    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2,
+                                             H_12);
 
-    for (int i = 0; i < 4; ++i)
-    {
-        for (int j = 0; j < 4; ++j)
-        {
-            EXPECT_NEAR(H_12_expected(i,j),H_12(i,j),0.0000000001) << "Elements differ at (" << i << "," << j << ")";
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            EXPECT_NEAR(H_12_expected(i, j), H_12(i, j), 0.0000000001)
+                << "Elements differ at (" << i << "," << j << ")";
         }
     }
 }
 
-TEST(HandEyeCalibration, PlanarMotion)
-{
+TEST(HandEyeCalibration, PlanarMotion) {
     HandEyeCalibration::setVerbose(false);
 
     Eigen::Matrix4d H_12_expected = Eigen::Matrix4d::Identity();
-    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized()).toRotationMatrix();
-    H_12_expected.block<3,1>(0,3) << 0.5, 0.6, 0.7;
+    H_12_expected.block<3, 3>(0, 0) =
+        Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized())
+            .toRotationMatrix();
+    H_12_expected.block<3, 1>(0, 3) << 0.5, 0.6, 0.7;
 
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > rvecs1, tvecs1, rvecs2, tvecs2;
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>>
+        rvecs1, tvecs1, rvecs2, tvecs2;
 
     int motionCount = 2;
-    for (int i = 0; i < motionCount; ++i)
-    {
+    for (int i = 0; i < motionCount; ++i) {
         double droll = d2r(random(-10.0, 10.0));
         droll = 0;
-        double dpitch =  d2r(random(-10.0, 10.0));
+        double dpitch = d2r(random(-10.0, 10.0));
         dpitch = 0;
-        double dyaw =  d2r(random(-10.0, 10.0));
+        double dyaw = d2r(random(-10.0, 10.0));
         double dx = random(-1.0, 1.0);
         double dy = random(-1.0, 1.0);
         double dz = random(-1.0, 1.0);
@@ -99,23 +101,24 @@ TEST(HandEyeCalibration, PlanarMotion)
             Eigen::AngleAxisd(droll, Eigen::Vector3d::UnitX());
 
         Eigen::Matrix4d H = Eigen::Matrix4d::Identity();
-        H.block<3,3>(0,0) = R;
-        H.block<3,1>(0,3) << dx, dy, dz;
+        H.block<3, 3>(0, 0) = R;
+        H.block<3, 1>(0, 3) << dx, dy, dz;
 
         Eigen::Matrix4d H_ = H.inverse();
         H = H_;
 
         Eigen::Vector3d rvec1, tvec1, rvec2, tvec2;
 
-        Eigen::AngleAxisd angleAxis1(H.block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis1(H.block<3, 3>(0, 0));
         rvec1 = angleAxis1.angle() * angleAxis1.axis();
 
-        tvec1 = H.block<3,1>(0,3);
+        tvec1 = H.block<3, 1>(0, 3);
 
-        Eigen::AngleAxisd angleAxis2((H_12_expected.inverse() * H * H_12_expected).block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis2(
+            (H_12_expected.inverse() * H * H_12_expected).block<3, 3>(0, 0));
         rvec2 = angleAxis2.angle() * angleAxis2.axis();
 
-        tvec2 = (H_12_expected.inverse() * H * H_12_expected).block<3,1>(0,3);
+        tvec2 = (H_12_expected.inverse() * H * H_12_expected).block<3, 1>(0, 3);
 
         rvecs1.push_back(rvec1);
         tvecs1.push_back(tvec1);
@@ -124,39 +127,41 @@ TEST(HandEyeCalibration, PlanarMotion)
     }
 
     Eigen::Matrix4d H_12;
-    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2, H_12, true);
+    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2,
+                                             H_12, true);
 
-    for (int i = 0; i < 4; ++i)
-    {
-        for (int j = 0; j < 4; ++j)
-        {
-            if (i == 2 && j == 3) continue;
-            EXPECT_NEAR(H_12_expected(i,j),H_12(i,j),0.0000000001) << "Elements differ at (" << i << "," << j << ")";
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            if (i == 2 && j == 3)
+                continue;
+            EXPECT_NEAR(H_12_expected(i, j), H_12(i, j), 0.0000000001)
+                << "Elements differ at (" << i << "," << j << ")";
         }
     }
 }
 
-TEST(HandEyeCalibration, PlanarMotionWithNoise)
-{
+TEST(HandEyeCalibration, PlanarMotionWithNoise) {
     HandEyeCalibration::setVerbose(true);
 
     Eigen::Matrix4d H_12_expected = Eigen::Matrix4d::Identity();
-    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized()).toRotationMatrix();
-    H_12_expected.block<3,1>(0,3) << 0.5, 0.6, 0.7;
+    H_12_expected.block<3, 3>(0, 0) =
+        Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.1, 0.2, 0.3).normalized())
+            .toRotationMatrix();
+    H_12_expected.block<3, 1>(0, 3) << 0.5, 0.6, 0.7;
 
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > rvecs1, tvecs1, rvecs2, tvecs2;
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>>
+        rvecs1, tvecs1, rvecs2, tvecs2;
 
     double scale = 1.5;
     int motionCount = 200;
     double sigma = 0.0005;
     cv::RNG rng;
-    for (int i = 0; i < motionCount; ++i)
-    {
+    for (int i = 0; i < motionCount; ++i) {
         double droll = d2r(random(-10.0, 10.0));
         droll = 0;
-        double dpitch =  d2r(random(-10.0, 10.0));
+        double dpitch = d2r(random(-10.0, 10.0));
         dpitch = 0;
-        double dyaw =  d2r(random(-100.0, 100.0));
+        double dyaw = d2r(random(-100.0, 100.0));
         double dx = random(-10.0, 10.0);
         double dy = random(-10.0, 10.0);
         double dz = random(-10.0, 10.0);
@@ -168,20 +173,21 @@ TEST(HandEyeCalibration, PlanarMotionWithNoise)
             Eigen::AngleAxisd(droll, Eigen::Vector3d::UnitX());
 
         Eigen::Matrix4d H = Eigen::Matrix4d::Identity();
-        H.block<3,3>(0,0) = R;
-        H.block<3,1>(0,3) << dx, dy, dz;
+        H.block<3, 3>(0, 0) = R;
+        H.block<3, 1>(0, 3) << dx, dy, dz;
 
         Eigen::Matrix4d H_ = H.inverse();
         H = H_;
 
         Eigen::Vector3d rvec1, tvec1, rvec2, tvec2;
 
-        Eigen::AngleAxisd angleAxis1(H.block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis1(H.block<3, 3>(0, 0));
         rvec1 = angleAxis1.angle() * angleAxis1.axis();
 
-        tvec1 = H.block<3,1>(0,3);
+        tvec1 = H.block<3, 1>(0, 3);
 
-        Eigen::AngleAxisd angleAxis2((H_12_expected.inverse() * H * H_12_expected).block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis2(
+            (H_12_expected.inverse() * H * H_12_expected).block<3, 3>(0, 0));
         rvec2 = angleAxis2.angle() * angleAxis2.axis();
         double roll, pitch, yaw;
         mat2RPY(angleAxis2.toRotationMatrix(), roll, pitch, yaw);
@@ -193,7 +199,7 @@ TEST(HandEyeCalibration, PlanarMotionWithNoise)
         angleAxis2.fromRotationMatrix(RPY2mat(roll, pitch, yaw));
         rvec2 = angleAxis2.angle() * angleAxis2.axis();
 
-        tvec2 = (H_12_expected.inverse() * H * H_12_expected).block<3,1>(0,3);
+        tvec2 = (H_12_expected.inverse() * H * H_12_expected).block<3, 1>(0, 3);
 
         rvecs1.push_back(rvec1);
         tvecs1.push_back(tvec1);
@@ -202,32 +208,38 @@ TEST(HandEyeCalibration, PlanarMotionWithNoise)
     }
 
     Eigen::Matrix4d H_12;
-    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2, H_12, true);
+    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2,
+                                             H_12, true);
     Eigen::Matrix4d H1 = H_12_expected;
     Eigen::Matrix4d H2 = H_12;
     std::cout << "# INFO: H_12_expected = " << std::endl;
-    std::cout << H_12_expected << std::endl; ;
-//    std::cout << H1 << std::endl << H2 << std::endl;
+    std::cout << H_12_expected << std::endl;
+    ;
+    //    std::cout << H1 << std::endl << H2 << std::endl;
 
-//    for (int i = 0; i < 4; ++i)
-//    {
-//        for (int j = 0; j < 4; ++j)
-//        {
-//            if (i == 2 && j == 3) continue;
-//            EXPECT_NEAR(H1(i,j),H2(i,j),0.0000000001) << "Elements differ at (" << i << "," << j << ")";
-//        }
-//    }
+    //    for (int i = 0; i < 4; ++i)
+    //    {
+    //        for (int j = 0; j < 4; ++j)
+    //        {
+    //            if (i == 2 && j == 3) continue;
+    //            EXPECT_NEAR(H1(i,j),H2(i,j),0.0000000001) << "Elements differ
+    //            at (" << i << "," << j << ")";
+    //        }
+    //    }
 }
 
 /*
 TEST(HandEyeCalibration, EstimateWithUnitTranslation)
 {
     Eigen::Matrix4d H_12_expected = Eigen::Matrix4d::Identity();
-//    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(0.0, 0.0, 0.3).normalized()).toRotationMatrix();
-//    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(1, 1, 0.3).normalized()).toRotationMatrix();
+//    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4,
+Eigen::Vector3d(0.0, 0.0, 0.3).normalized()).toRotationMatrix();
+//    H_12_expected.block<3,3>(0,0) = Eigen::AngleAxisd(0.4, Eigen::Vector3d(1,
+1, 0.3).normalized()).toRotationMatrix();
     H_12_expected.block<3,1>(0,3) << 0.5, 0.6, 0.7;
 
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > rvecs1, tvecs1, rvecs2, tvecs2;
+    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >
+rvecs1, tvecs1, rvecs2, tvecs2;
 
     int motionCount = 2;
     for (int i = 0; i < motionCount; ++i)
@@ -253,7 +265,8 @@ TEST(HandEyeCalibration, EstimateWithUnitTranslation)
 
         Eigen::Vector3d rvec1, tvec1, rvec2, tvec2;
 
-        Eigen::AngleAxisd angleAxis1((H_12_expected * H * H_12_expected.inverse()).block<3,3>(0,0));
+        Eigen::AngleAxisd angleAxis1((H_12_expected * H *
+H_12_expected.inverse()).block<3,3>(0,0));
         rvec1 = angleAxis1.angle() * angleAxis1.axis();
 
         tvec1 = (H_12_expected * H * H_12_expected.inverse()).block<3,1>(0,3);
@@ -271,16 +284,17 @@ TEST(HandEyeCalibration, EstimateWithUnitTranslation)
     }
 
     Eigen::Matrix4d H_12;
-    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2, H_12, true);
+    HandEyeCalibration::estimateHandEyeScrew(rvecs1, tvecs1, rvecs2, tvecs2,
+H_12, true);
 
     for (int i = 0; i < 4; ++i)
     {
         for (int j = 0; j < 4; ++j)
         {
-            EXPECT_NEAR(H_12_expected(i,j),H_12(i,j),0.0000000001) << "Elements differ at (" << i << "," << j << ")";
+            EXPECT_NEAR(H_12_expected(i,j),H_12(i,j),0.0000000001) << "Elements
+differ at (" << i << "," << j << ")";
         }
     }
 }
 */
-
 }

--- a/src/camodocal/calib/QuaternionMapping.h
+++ b/src/camodocal/calib/QuaternionMapping.h
@@ -6,46 +6,38 @@
 
 #include "DualQuaternion.h"
 
-namespace camodocal
-{
+namespace camodocal {
 
-template<typename T>
-Eigen::Quaternion<T> expq(const Eigen::Quaternion<T>& q)
-{
-	T a = q.vec().norm(); 
-	T exp_w = exp(q.w());
+template <typename T> Eigen::Quaternion<T> expq(const Eigen::Quaternion<T>& q) {
+    T a = q.vec().norm();
+    T exp_w = exp(q.w());
 
-	if (a == T(0))
-	{
-	    return Eigen::Quaternion<T>(exp_w, 0, 0, 0);
-	}
+    if (a == T(0)) {
+        return Eigen::Quaternion<T>(exp_w, 0, 0, 0);
+    }
 
-	Eigen::Quaternion<T> res;
-	res.w() = exp_w * T(cos(a));
-	res.vec() = exp_w * T(sinc(a)) * q.vec();
+    Eigen::Quaternion<T> res;
+    res.w() = exp_w * T(cos(a));
+    res.vec() = exp_w * T(sinc(a)) * q.vec();
 
-	return res; 
+    return res;
 }
 
-template<typename T>
-Eigen::Quaternion<T> logq(const Eigen::Quaternion<T>& q)
-{
-	T exp_w = q.norm();
-	T w = log(exp_w);
-	T a = acos(q.w() / exp_w); 	
+template <typename T> Eigen::Quaternion<T> logq(const Eigen::Quaternion<T>& q) {
+    T exp_w = q.norm();
+    T w = log(exp_w);
+    T a = acos(q.w() / exp_w);
 
-	if (a == T(0))
-	{
-	    return Eigen::Quaternion<T>(w, T(0), T(0), T(0));
-	}
-	
-	Eigen::Quaternion<T> res;
-	res.w() = w;
-	res.vec() = q.vec() / exp_w / (sin(a) / a);
+    if (a == T(0)) {
+        return Eigen::Quaternion<T>(w, T(0), T(0), T(0));
+    }
 
-	return res; 
+    Eigen::Quaternion<T> res;
+    res.w() = w;
+    res.vec() = q.vec() / exp_w / (sin(a) / a);
+
+    return res;
 }
-
 }
 
 #endif

--- a/src/handeye_calibration.cpp
+++ b/src/handeye_calibration.cpp
@@ -1,531 +1,554 @@
-#include <ros/ros.h>
-#include <tf/transform_listener.h>
-#include <tf_conversions/tf_eigen.h>
+#include "ceres/ceres.h"
+#include "ceres/types.h"
 #include <camodocal/calib/HandEyeCalibration.h>
 #include <eigen3/Eigen/Geometry>
-#include <termios.h>
 #include <opencv2/core/eigen.hpp>
-#include <ceres/ceres.h>
-#include <ceres/types.h>
+#include <ros/ros.h>
+#include <termios.h>
+#include <tf/transform_listener.h>
+#include <tf_conversions/tf_eigen.h>
 
-typedef std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > eigenVector;
+typedef std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d>>
+    eigenVector;
 
-typedef std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d> > EigenAffineVector;
-
+typedef std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d>>
+    EigenAffineVector;
 
 ///////////////////////////////////////////////////////
 // DEFINING GLOBAL VARIABLES
 
-
 std::string ARTagTFname, cameraTFname;
 std::string EETFname, baseTFname;
-tf::TransformListener * listener;
+tf::TransformListener* listener;
 Eigen::Affine3d firstEEInverse, firstCamInverse;
 bool firstTransform = true;
 eigenVector tvecsArm, rvecsArm, tvecsFiducial, rvecsFiducial;
 
 EigenAffineVector baseToTip, cameraToTag;
 
-
-template<typename Input>
-Eigen::Vector3d eigenRotToEigenVector3dAngleAxis(Input eigenQuat){
+template <typename Input>
+Eigen::Vector3d eigenRotToEigenVector3dAngleAxis(Input eigenQuat) {
     Eigen::AngleAxisd ax3d(eigenQuat);
-    return ax3d.angle()*ax3d.axis();
+    return ax3d.angle() * ax3d.axis();
 }
 
 /// @return 0 on success, otherwise error code
-int writeTransformPairsToFile(const  EigenAffineVector& t1, const EigenAffineVector& t2, std::string filename)
-{
-	std::cerr << "Writing pairs to \"" << filename << "\"...\n";
-	cv::FileStorage fs(filename, cv::FileStorage::WRITE);
-	int frameCount = t1.size();
-	fs << "frameCount" << frameCount;
-	auto t1_it = t1.begin();
-	auto t2_it = t2.begin();
+int writeTransformPairsToFile(const EigenAffineVector& t1,
+                              const EigenAffineVector& t2,
+                              std::string filename) {
+    std::cerr << "Writing pairs to \"" << filename << "\"...\n";
+    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
+    int frameCount = t1.size();
+    fs << "frameCount" << frameCount;
+    auto t1_it = t1.begin();
+    auto t2_it = t2.begin();
 
-	if(fs.isOpened())
-	{
+    if (fs.isOpened()) {
 
-		for (int i = 0; i < t1.size(); ++i, ++t1_it, ++t2_it){
-			cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4,4);
-			cv::eigen2cv(t1_it->matrix(),t1cv);
-			cv::Mat_<double> t2cv = cv::Mat_<double>::ones(4,4);
-			cv::eigen2cv(t2_it->matrix(),t2cv);
+        for (int i = 0; i < t1.size(); ++i, ++t1_it, ++t2_it) {
+            cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4, 4);
+            cv::eigen2cv(t1_it->matrix(), t1cv);
+            cv::Mat_<double> t2cv = cv::Mat_<double>::ones(4, 4);
+            cv::eigen2cv(t2_it->matrix(), t2cv);
 
+            std::stringstream ss1;
+            ss1 << "T1_" << i;
+            fs << ss1.str() << t1cv;
 
-			std::stringstream ss1;
-			ss1 << "T1_" << i;
-			fs << ss1.str() << t1cv;
-
-			std::stringstream ss2;
-			ss2 << "T2_" << i;
-			fs << ss2.str() << t2cv;
-
-
-		}
-		fs.release();
-	} else {
-		std::cerr << "failed to open output file " << filename << "\n";
-		return 1;
-	}
-	return 0;
-}
-
-
-
-/// @return 0 on success, otherwise error code
-int readTransformPairsFromFile(std::string filename, EigenAffineVector& t1, EigenAffineVector& t2)
-{
-	cv::FileStorage fs(filename, cv::FileStorage::READ);
-	int frameCount;
-
-	fs["frameCount"] >> frameCount;
-	auto t1_it = std::back_inserter(t1);
-	auto t2_it = std::back_inserter(t2);
-
-	if(fs.isOpened())
-	{
-
-		for (int i = 0; i < frameCount; ++i, ++t1_it, ++t2_it){
-			// read in frame one
-			{
-				cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4,4);
-				std::stringstream ss1;
-				ss1 << "T1_" << i;
-				fs[ss1.str()] >> t1cv;
-				Eigen::Affine3d t1e;
-				cv::cv2eigen(t1cv,t1e.matrix());
-				*t1_it = t1e;
-			}
-
-			// read in frame two
-			{
-				cv::Mat_<double> t2cv = cv::Mat_<double>::ones(4,4);
-				std::stringstream ss2;
-				ss2 << "T2_" << i;
-				fs[ss2.str()] >> t2cv;
-				Eigen::Affine3d t2e;
-				cv::cv2eigen(t2cv,t2e.matrix());
-				*t2_it = t2e;
-			}
-
-		}
-		fs.release();
-	} else {
-		std::cerr << "failed to open input file " << filename << "\n";
-		return 1;
-	}
-	return 0;
-}
-
-Eigen::Affine3d estimateHandEye(const EigenAffineVector& baseToTip, const EigenAffineVector& camToTag)
-{
-
-	auto t1_it = baseToTip.begin();
-	auto t2_it = camToTag.begin();
-
-	Eigen::Affine3d firstEEInverse, firstCamInverse;
-	eigenVector tvecsArm, rvecsArm, tvecsFiducial, rvecsFiducial;
-
-	bool firstTransform = true;
-
-	for (int i = 0; i < baseToTip.size(); ++i, ++t1_it, ++t2_it){
-		auto& eigenEE = *t1_it;
-		auto& eigenCam = *t2_it;
-		if (firstTransform)
-		{
-			firstEEInverse = eigenEE.inverse();
-			firstCamInverse = eigenCam.inverse();
-			ROS_INFO("Adding first transformation.");
-			firstTransform = false;
-		}
-		else
-		{
-			Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
-			Eigen::Affine3d fiducialInFirstFiducialBase = firstCamInverse * eigenCam;
-
-			rvecsArm.push_back(     eigenRotToEigenVector3dAngleAxis(robotTipinFirstTipBase.rotation()        ));
-		    tvecsArm.push_back(                                      robotTipinFirstTipBase.translation()     );
-		    
-		    rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(fiducialInFirstFiducialBase.rotation()   ));
-		    tvecsFiducial.push_back(                                 fiducialInFirstFiducialBase.translation());
-			ROS_INFO("Hand Eye Calibration Transform Pair Added");
-
-			Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3); r_tmp[3] = 0;
-			Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3); c_tmp[3] = 0;
-			
-			std::cerr << "L2Norm EE: "  << robotTipinFirstTipBase.matrix().block(0,3,3,1).norm() << " vs Cam:" << fiducialInFirstFiducialBase.matrix().block(0,3,3,1).norm()<<std::endl; 
-		}
-		std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
-		std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
-
-
-	}
-
-	  	camodocal::HandEyeCalibration calib;
-	  	Eigen::Matrix4d result;
-	  	calib.estimateHandEyeScrew(rvecsArm,tvecsArm,rvecsFiducial,tvecsFiducial,result,false);
-	  	std::cerr << "Result from " << EETFname << " to " << ARTagTFname <<":\n" << result << std::endl;
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffine(result);
-	  	std::cerr << "Translation (x,y,z) : " << resultAffine.translation().transpose() << std::endl;
-	  	Eigen::Quaternion<double> quaternionResult (resultAffine.rotation());
-	  	std::stringstream ss;
-	  	ss << quaternionResult.w() << ", " << quaternionResult.x() << ", " << quaternionResult.y() << ", " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
-
-
-	  	std::cerr << "Result from " << ARTagTFname << " to " <<EETFname  <<":\n" << result << std::endl;
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffineInv = resultAffine.inverse();
-	  	std::cerr << "Inverted translation (x,y,z) : " << resultAffineInv.translation().transpose() << std::endl;
-	  	quaternionResult = Eigen::Quaternion<double>(resultAffineInv.rotation());
-	  	ss.clear();
-	  	ss << quaternionResult.w() << " " << quaternionResult.x() << " " << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Inverted rotation (w,x,y,z): " << ss.str() << std::endl;
-      return resultAffine;
-}
-
-Eigen::Affine3d estimateHandEye(const EigenAffineVector& baseToTip, const EigenAffineVector& camToTag,ceres::Solver::Summary& summary)
-{
-
-	auto t1_it = baseToTip.begin();
-	auto t2_it = camToTag.begin();
-
-	Eigen::Affine3d firstEEInverse, firstCamInverse;
-	eigenVector tvecsArm, rvecsArm, tvecsFiducial, rvecsFiducial;
-
-	bool firstTransform = true;
-
-	for (int i = 0; i < baseToTip.size(); ++i, ++t1_it, ++t2_it){
-		auto& eigenEE = *t1_it;
-		auto& eigenCam = *t2_it;
-		if (firstTransform)
-		{
-			firstEEInverse = eigenEE.inverse();
-			firstCamInverse = eigenCam.inverse();
-			ROS_INFO("Adding first transformation.");
-			firstTransform = false;
-		}
-		else
-		{
-			Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
-			Eigen::Affine3d fiducialInFirstFiducialBase = firstCamInverse * eigenCam;
-
-			rvecsArm.push_back(     eigenRotToEigenVector3dAngleAxis(robotTipinFirstTipBase.rotation()        ));
-		    tvecsArm.push_back(                                      robotTipinFirstTipBase.translation()     );
-		    
-		    rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(fiducialInFirstFiducialBase.rotation()   ));
-		    tvecsFiducial.push_back(                                 fiducialInFirstFiducialBase.translation());
-			ROS_INFO("Hand Eye Calibration Transform Pair Added");
-
-			Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3); r_tmp[3] = 0;
-			Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3); c_tmp[3] = 0;
-			
-			std::cerr << "L2Norm EE: "  << robotTipinFirstTipBase.matrix().block(0,3,3,1).norm() << " vs Cam:" << fiducialInFirstFiducialBase.matrix().block(0,3,3,1).norm()<<std::endl; 
-		}
-		std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
-		std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
-
-
-	}
-
-	  	camodocal::HandEyeCalibration calib;
-	  	Eigen::Matrix4d result;
-	  	calib.estimateHandEyeScrew(rvecsArm,tvecsArm,rvecsFiducial,tvecsFiducial,result,summary,false);
-	  	std::cerr << "Result from " << EETFname << " to " << ARTagTFname <<":\n" << result << std::endl;
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffine(result);
-	  	std::cerr << "Translation (x,y,z) : " << resultAffine.translation().transpose() << std::endl;
-	  	Eigen::Quaternion<double> quaternionResult (resultAffine.rotation());
-	  	std::stringstream ss;
-	  	ss << quaternionResult.w() << ", " << quaternionResult.x() << ", " << quaternionResult.y() << ", " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
-
-
-	  	std::cerr << "Result from " << ARTagTFname << " to " <<EETFname  <<":\n" << result << std::endl;
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffineInv = resultAffine.inverse();
-	  	std::cerr << "Inverted translation (x,y,z) : " << resultAffineInv.translation().transpose() << std::endl;
-	  	quaternionResult = Eigen::Quaternion<double>(resultAffineInv.rotation());
-	  	ss.clear();
-	  	ss << quaternionResult.w() << " " << quaternionResult.x() << " " << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Inverted rotation (w,x,y,z): " << ss.str() << std::endl;
-      return resultAffine;
-}
-
-
-void writeCalibration(const Eigen::Affine3d &result, const std::string &filename) {
-		cv::FileStorage fs(filename, cv::FileStorage::WRITE);
-
-	std::cerr << "Writing calibration to \"" << filename << "\"...\n";
-	if(fs.isOpened())
-	{
-		cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4,4);
-		cv::eigen2cv(result.matrix(),t1cv);
-
-		fs << "ArmTipToMarkerTagTransform" << t1cv;
-
-		fs.release();
-	}
-}
-
-void writeCalibration(const Eigen::Affine3d &result,
-                      const std::string &filename, ceres::Solver::Summary& summary) {
-  cv::FileStorage fs(filename, cv::FileStorage::WRITE);
-
-  std::cerr << "FULL CONVERGENCE REPORT \"" <<  "\"...\n";
-  std::cout << summary.BriefReport() << "\n";
-  std::cout << summary.termination_type << "\n";
-  std::cerr << "Writing calibration to \"" << filename << "\"...\n";
-  if(fs.isOpened())
-    {
-      cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4,4);
-      cv::eigen2cv(result.matrix(),t1cv);
-
-      fs << "ArmTipToMarkerTagTransform" << t1cv;
-      fs << "initial_cost" << summary.initial_cost;
-      fs << "final_cost" << summary.final_cost;
-      fs << "change_cost" << summary.initial_cost - summary.final_cost;
-      fs << "termination_type" << summary.termination_type;
-      fs << "num_successful_iteration" << summary.num_successful_steps;
-      fs << "num_unsuccessful_iteration" << summary.num_unsuccessful_steps;
-      fs << "num_iteration" << summary.num_unsuccessful_steps +summary.num_successful_steps;
-      fs.release();
+            std::stringstream ss2;
+            ss2 << "T2_" << i;
+            fs << ss2.str() << t2cv;
+        }
+        fs.release();
+    } else {
+        std::cerr << "failed to open output file " << filename << "\n";
+        return 1;
     }
+    return 0;
 }
 
+/// @return 0 on success, otherwise error code
+int readTransformPairsFromFile(std::string filename, EigenAffineVector& t1,
+                               EigenAffineVector& t2) {
+    cv::FileStorage fs(filename, cv::FileStorage::READ);
+    int frameCount;
+
+    fs["frameCount"] >> frameCount;
+    auto t1_it = std::back_inserter(t1);
+    auto t2_it = std::back_inserter(t2);
+
+    if (fs.isOpened()) {
+
+        for (int i = 0; i < frameCount; ++i, ++t1_it, ++t2_it) {
+            // read in frame one
+            {
+                cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4, 4);
+                std::stringstream ss1;
+                ss1 << "T1_" << i;
+                fs[ss1.str()] >> t1cv;
+                Eigen::Affine3d t1e;
+                cv::cv2eigen(t1cv, t1e.matrix());
+                *t1_it = t1e;
+            }
+
+            // read in frame two
+            {
+                cv::Mat_<double> t2cv = cv::Mat_<double>::ones(4, 4);
+                std::stringstream ss2;
+                ss2 << "T2_" << i;
+                fs[ss2.str()] >> t2cv;
+                Eigen::Affine3d t2e;
+                cv::cv2eigen(t2cv, t2e.matrix());
+                *t2_it = t2e;
+            }
+        }
+        fs.release();
+    } else {
+        std::cerr << "failed to open input file " << filename << "\n";
+        return 1;
+    }
+    return 0;
+}
+
+Eigen::Affine3d estimateHandEye(const EigenAffineVector& baseToTip,
+                                const EigenAffineVector& camToTag) {
+
+    auto t1_it = baseToTip.begin();
+    auto t2_it = camToTag.begin();
+
+    Eigen::Affine3d firstEEInverse, firstCamInverse;
+    eigenVector tvecsArm, rvecsArm, tvecsFiducial, rvecsFiducial;
+
+    bool firstTransform = true;
+
+    for (int i = 0; i < baseToTip.size(); ++i, ++t1_it, ++t2_it) {
+        auto& eigenEE = *t1_it;
+        auto& eigenCam = *t2_it;
+        if (firstTransform) {
+            firstEEInverse = eigenEE.inverse();
+            firstCamInverse = eigenCam.inverse();
+            ROS_INFO("Adding first transformation.");
+            firstTransform = false;
+        } else {
+            Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
+            Eigen::Affine3d fiducialInFirstFiducialBase =
+                firstCamInverse * eigenCam;
+
+            rvecsArm.push_back(eigenRotToEigenVector3dAngleAxis(
+                robotTipinFirstTipBase.rotation()));
+            tvecsArm.push_back(robotTipinFirstTipBase.translation());
+
+            rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(
+                fiducialInFirstFiducialBase.rotation()));
+            tvecsFiducial.push_back(fiducialInFirstFiducialBase.translation());
+            ROS_INFO("Hand Eye Calibration Transform Pair Added");
+
+            Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3);
+            r_tmp[3] = 0;
+            Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3);
+            c_tmp[3] = 0;
+
+            std::cerr
+                << "L2Norm EE: "
+                << robotTipinFirstTipBase.matrix().block(0, 3, 3, 1).norm()
+                << " vs Cam:"
+                << fiducialInFirstFiducialBase.matrix().block(0, 3, 3, 1).norm()
+                << std::endl;
+        }
+        std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
+        std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
+    }
+
+    camodocal::HandEyeCalibration calib;
+    Eigen::Matrix4d result;
+    calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial, tvecsFiducial,
+                               result, false);
+    std::cerr << "Result from " << EETFname << " to " << ARTagTFname << ":\n"
+              << result << std::endl;
+    Eigen::Transform<double, 3, Eigen::Affine> resultAffine(result);
+    std::cerr << "Translation (x,y,z) : "
+              << resultAffine.translation().transpose() << std::endl;
+    Eigen::Quaternion<double> quaternionResult(resultAffine.rotation());
+    std::stringstream ss;
+    ss << quaternionResult.w() << ", " << quaternionResult.x() << ", "
+       << quaternionResult.y() << ", " << quaternionResult.z() << std::endl;
+    std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
+
+    std::cerr << "Result from " << ARTagTFname << " to " << EETFname << ":\n"
+              << result << std::endl;
+    Eigen::Transform<double, 3, Eigen::Affine> resultAffineInv =
+        resultAffine.inverse();
+    std::cerr << "Inverted translation (x,y,z) : "
+              << resultAffineInv.translation().transpose() << std::endl;
+    quaternionResult = Eigen::Quaternion<double>(resultAffineInv.rotation());
+    ss.clear();
+    ss << quaternionResult.w() << " " << quaternionResult.x() << " "
+       << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
+    std::cerr << "Inverted rotation (w,x,y,z): " << ss.str() << std::endl;
+    return resultAffine;
+}
 
 Eigen::Affine3d estimateHandEye(const EigenAffineVector& baseToTip,
                                 const EigenAffineVector& camToTag,
-                                const std::string &filename,
-                                const bool addSolverSummary)
-{
-  if (addSolverSummary) {
+                                ceres::Solver::Summary& summary) {
 
-    ceres::Solver::Summary summary;
-    auto result = estimateHandEye(baseToTip,camToTag,summary);
-    writeCalibration(result, filename, summary);
-    return result;
-  }
-	else {
-    auto result = estimateHandEye(baseToTip,camToTag);
-    writeCalibration(result, filename);
-    return result;
-  }
+    auto t1_it = baseToTip.begin();
+    auto t2_it = camToTag.begin();
+
+    Eigen::Affine3d firstEEInverse, firstCamInverse;
+    eigenVector tvecsArm, rvecsArm, tvecsFiducial, rvecsFiducial;
+
+    bool firstTransform = true;
+
+    for (int i = 0; i < baseToTip.size(); ++i, ++t1_it, ++t2_it) {
+        auto& eigenEE = *t1_it;
+        auto& eigenCam = *t2_it;
+        if (firstTransform) {
+            firstEEInverse = eigenEE.inverse();
+            firstCamInverse = eigenCam.inverse();
+            ROS_INFO("Adding first transformation.");
+            firstTransform = false;
+        } else {
+            Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
+            Eigen::Affine3d fiducialInFirstFiducialBase =
+                firstCamInverse * eigenCam;
+
+            rvecsArm.push_back(eigenRotToEigenVector3dAngleAxis(
+                robotTipinFirstTipBase.rotation()));
+            tvecsArm.push_back(robotTipinFirstTipBase.translation());
+
+            rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(
+                fiducialInFirstFiducialBase.rotation()));
+            tvecsFiducial.push_back(fiducialInFirstFiducialBase.translation());
+            ROS_INFO("Hand Eye Calibration Transform Pair Added");
+
+            Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3);
+            r_tmp[3] = 0;
+            Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3);
+            c_tmp[3] = 0;
+
+            std::cerr
+                << "L2Norm EE: "
+                << robotTipinFirstTipBase.matrix().block(0, 3, 3, 1).norm()
+                << " vs Cam:"
+                << fiducialInFirstFiducialBase.matrix().block(0, 3, 3, 1).norm()
+                << std::endl;
+        }
+        std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
+        std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
+    }
+
+    camodocal::HandEyeCalibration calib;
+    Eigen::Matrix4d result;
+    calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial, tvecsFiducial,
+                               result, summary, false);
+    std::cerr << "Result from " << EETFname << " to " << ARTagTFname << ":\n"
+              << result << std::endl;
+    Eigen::Transform<double, 3, Eigen::Affine> resultAffine(result);
+    std::cerr << "Translation (x,y,z) : "
+              << resultAffine.translation().transpose() << std::endl;
+    Eigen::Quaternion<double> quaternionResult(resultAffine.rotation());
+    std::stringstream ss;
+    ss << quaternionResult.w() << ", " << quaternionResult.x() << ", "
+       << quaternionResult.y() << ", " << quaternionResult.z() << std::endl;
+    std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
+
+    std::cerr << "Result from " << ARTagTFname << " to " << EETFname << ":\n"
+              << result << std::endl;
+    Eigen::Transform<double, 3, Eigen::Affine> resultAffineInv =
+        resultAffine.inverse();
+    std::cerr << "Inverted translation (x,y,z) : "
+              << resultAffineInv.translation().transpose() << std::endl;
+    quaternionResult = Eigen::Quaternion<double>(resultAffineInv.rotation());
+    ss.clear();
+    ss << quaternionResult.w() << " " << quaternionResult.x() << " "
+       << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
+    std::cerr << "Inverted rotation (w,x,y,z): " << ss.str() << std::endl;
+    return resultAffine;
 }
 
-// function getch is from http://answers.ros.org/question/63491/keyboard-key-pressed/
-int getch()
-{
-  static struct termios oldt, newt;
-  tcgetattr( STDIN_FILENO, &oldt);           // save old settings
-  newt = oldt;
-  newt.c_lflag &= ~(ICANON);                 // disable buffering      
-  tcsetattr( STDIN_FILENO, TCSANOW, &newt);  // apply new settings
+void writeCalibration(const Eigen::Affine3d& result,
+                      const std::string& filename) {
+    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
 
-  int c = getchar();  // read character (non-blocking)
+    std::cerr << "Writing calibration to \"" << filename << "\"...\n";
+    if (fs.isOpened()) {
+        cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4, 4);
+        cv::eigen2cv(result.matrix(), t1cv);
 
-  tcsetattr( STDIN_FILENO, TCSANOW, &oldt);  // restore old settings
-  return c;
+        fs << "ArmTipToMarkerTagTransform" << t1cv;
+
+        fs.release();
+    }
 }
 
-void addFrame()
-{
-	ros::Time now = ros::Time::now();
-	tf::StampedTransform EETransform, CamTransform; 
-	bool hasEE =true, hasCam = true;
+void writeCalibration(const Eigen::Affine3d& result,
+                      const std::string& filename,
+                      ceres::Solver::Summary& summary) {
+    cv::FileStorage fs(filename, cv::FileStorage::WRITE);
 
+    std::cerr << "FULL CONVERGENCE REPORT \""
+              << "\"...\n";
+    std::cout << summary.BriefReport() << "\n";
+    std::cout << summary.termination_type << "\n";
+    std::cerr << "Writing calibration to \"" << filename << "\"...\n";
+    if (fs.isOpened()) {
+        cv::Mat_<double> t1cv = cv::Mat_<double>::ones(4, 4);
+        cv::eigen2cv(result.matrix(), t1cv);
 
+        fs << "ArmTipToMarkerTagTransform" << t1cv;
+        fs << "initial_cost" << summary.initial_cost;
+        fs << "final_cost" << summary.final_cost;
+        fs << "change_cost" << summary.initial_cost - summary.final_cost;
+        fs << "termination_type" << summary.termination_type;
+        fs << "num_successful_iteration" << summary.num_successful_steps;
+        fs << "num_unsuccessful_iteration" << summary.num_unsuccessful_steps;
+        fs << "num_iteration"
+           << summary.num_unsuccessful_steps + summary.num_successful_steps;
+        fs.release();
+    }
+}
 
+Eigen::Affine3d estimateHandEye(const EigenAffineVector& baseToTip,
+                                const EigenAffineVector& camToTag,
+                                const std::string& filename,
+                                const bool addSolverSummary) {
+    if (addSolverSummary) {
 
-	if (listener->waitForTransform(cameraTFname,ARTagTFname,now,ros::Duration(1)))
-		listener->lookupTransform(cameraTFname,ARTagTFname,now,CamTransform);
-	else
-	{
-		hasCam = false;
-		ROS_WARN("Fail to Cam TF transform between %s to %s", cameraTFname.c_str(), ARTagTFname.c_str());
-	}
+        ceres::Solver::Summary summary;
+        auto result = estimateHandEye(baseToTip, camToTag, summary);
+        writeCalibration(result, filename, summary);
+        return result;
+    } else {
+        auto result = estimateHandEye(baseToTip, camToTag);
+        writeCalibration(result, filename);
+        return result;
+    }
+}
 
-	if (listener->waitForTransform(baseTFname,EETFname,now,ros::Duration(1)))
-		listener->lookupTransform(baseTFname,EETFname,now,EETransform);
-	else
-	{
-		hasEE = false;
-		ROS_WARN("Fail to EE TF transform between %s to %s", baseTFname.c_str(), EETFname.c_str());
-	}
+// function getch is from
+// http://answers.ros.org/question/63491/keyboard-key-pressed/
+int getch() {
+    static struct termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt); // save old settings
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON);               // disable buffering
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt); // apply new settings
 
-	if (hasEE and hasCam)
-	{
-		Eigen::Affine3d eigenEE, eigenCam;
-		tf::transformTFToEigen(EETransform, eigenEE);
-		tf::transformTFToEigen(CamTransform, eigenCam);
-        
+    int c = getchar(); // read character (non-blocking)
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt); // restore old settings
+    return c;
+}
+
+void addFrame() {
+    ros::Time now = ros::Time::now();
+    tf::StampedTransform EETransform, CamTransform;
+    bool hasEE = true, hasCam = true;
+
+    if (listener->waitForTransform(cameraTFname, ARTagTFname, now,
+                                   ros::Duration(1)))
+        listener->lookupTransform(cameraTFname, ARTagTFname, now, CamTransform);
+    else {
+        hasCam = false;
+        ROS_WARN("Fail to Cam TF transform between %s to %s",
+                 cameraTFname.c_str(), ARTagTFname.c_str());
+    }
+
+    if (listener->waitForTransform(baseTFname, EETFname, now, ros::Duration(1)))
+        listener->lookupTransform(baseTFname, EETFname, now, EETransform);
+    else {
+        hasEE = false;
+        ROS_WARN("Fail to EE TF transform between %s to %s", baseTFname.c_str(),
+                 EETFname.c_str());
+    }
+
+    if (hasEE and hasCam) {
+        Eigen::Affine3d eigenEE, eigenCam;
+        tf::transformTFToEigen(EETransform, eigenEE);
+        tf::transformTFToEigen(CamTransform, eigenCam);
+
         baseToTip.push_back(eigenEE);
         cameraToTag.push_back(eigenCam);
 
-		if (firstTransform)
-		{
-			firstEEInverse = eigenEE.inverse();
-			firstCamInverse = eigenCam.inverse();
-			ROS_INFO("Adding first transformation.");
-			firstTransform = false;
-		}
-		else
-		{
-			Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
-			Eigen::Affine3d fiducialInFirstFiducialBase = firstCamInverse * eigenCam;
+        if (firstTransform) {
+            firstEEInverse = eigenEE.inverse();
+            firstCamInverse = eigenCam.inverse();
+            ROS_INFO("Adding first transformation.");
+            firstTransform = false;
+        } else {
+            Eigen::Affine3d robotTipinFirstTipBase = firstEEInverse * eigenEE;
+            Eigen::Affine3d fiducialInFirstFiducialBase =
+                firstCamInverse * eigenCam;
 
-			rvecsArm.push_back(     eigenRotToEigenVector3dAngleAxis(robotTipinFirstTipBase.rotation()        ));
-		    tvecsArm.push_back(                                      robotTipinFirstTipBase.translation()     );
-		    
-		    rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(fiducialInFirstFiducialBase.rotation()   ));
-		    tvecsFiducial.push_back(                                 fiducialInFirstFiducialBase.translation());
-			ROS_INFO("Hand Eye Calibration Transform Pair Added");
+            rvecsArm.push_back(eigenRotToEigenVector3dAngleAxis(
+                robotTipinFirstTipBase.rotation()));
+            tvecsArm.push_back(robotTipinFirstTipBase.translation());
 
-			std::cerr << "EE Relative transform: \n" << robotTipinFirstTipBase.matrix() << std::endl;
-			std::cerr << "Cam Relative transform: \n" << fiducialInFirstFiducialBase.matrix() << std::endl;
-		      std::cerr << "EE pos: ("
-		        << EETransform.getOrigin().getX() << ", "
-		        << EETransform.getOrigin().getY() << ", "
-		        << EETransform.getOrigin().getZ() << ")\n";
-		      std::cerr << "EE rot: ("
-		        << EETransform.getRotation().getAxis().getX() << ", "
-		        << EETransform.getRotation().getAxis().getY() << ", "
-		        << EETransform.getRotation().getAxis().getZ() << ", "
-		        << EETransform.getRotation().getW() << ")\n";
-			Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3); r_tmp[3] = 0;
-			Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3); c_tmp[3] = 0;
-			
-			std::cerr << "L2Norm EE: "  << robotTipinFirstTipBase.matrix().block(0,3,3,1).norm() << " vs Cam:" << fiducialInFirstFiducialBase.matrix().block(0,3,3,1).norm()<<std::endl; 
-		}
-		std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
-		std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
-	}
-	else
-	{
-		ROS_WARN("Fail to get one/both of needed TF transform");
-	}
+            rvecsFiducial.push_back(eigenRotToEigenVector3dAngleAxis(
+                fiducialInFirstFiducialBase.rotation()));
+            tvecsFiducial.push_back(fiducialInFirstFiducialBase.translation());
+            ROS_INFO("Hand Eye Calibration Transform Pair Added");
+
+            std::cerr << "EE Relative transform: \n"
+                      << robotTipinFirstTipBase.matrix() << std::endl;
+            std::cerr << "Cam Relative transform: \n"
+                      << fiducialInFirstFiducialBase.matrix() << std::endl;
+            std::cerr << "EE pos: (" << EETransform.getOrigin().getX() << ", "
+                      << EETransform.getOrigin().getY() << ", "
+                      << EETransform.getOrigin().getZ() << ")\n";
+            std::cerr << "EE rot: ("
+                      << EETransform.getRotation().getAxis().getX() << ", "
+                      << EETransform.getRotation().getAxis().getY() << ", "
+                      << EETransform.getRotation().getAxis().getZ() << ", "
+                      << EETransform.getRotation().getW() << ")\n";
+            Eigen::Vector4d r_tmp = robotTipinFirstTipBase.matrix().col(3);
+            r_tmp[3] = 0;
+            Eigen::Vector4d c_tmp = fiducialInFirstFiducialBase.matrix().col(3);
+            c_tmp[3] = 0;
+
+            std::cerr
+                << "L2Norm EE: "
+                << robotTipinFirstTipBase.matrix().block(0, 3, 3, 1).norm()
+                << " vs Cam:"
+                << fiducialInFirstFiducialBase.matrix().block(0, 3, 3, 1).norm()
+                << std::endl;
+        }
+        std::cerr << "EE transform: \n" << eigenEE.matrix() << std::endl;
+        std::cerr << "Cam transform: \n" << eigenCam.matrix() << std::endl;
+    } else {
+        ROS_WARN("Fail to get one/both of needed TF transform");
+    }
 }
 
-int main (int argc, char** argv)
-{
-  ros::init(argc,argv,"handeye_calib_camodocal");    
-  ros::NodeHandle nh("~");
-  std::string transformPairsRecordFile;
-  std::string transformPairsLoadFile;
-  std::string calibratedTransformFile;
-  bool loadTransformsFromFile = false;
-  bool addSolverSummary = false;
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "handeye_calib_camodocal");
+    ros::NodeHandle nh("~");
+    std::string transformPairsRecordFile;
+    std::string transformPairsLoadFile;
+    std::string calibratedTransformFile;
+    bool loadTransformsFromFile = false;
+    bool addSolverSummary = false;
 
-  //getting TF names
-  nh.param("ARTagTF", ARTagTFname,std::string("/camera_2/ar_marker_0"));
-  nh.param("cameraTF", cameraTFname,std::string("/camera_2_link"));
-  nh.param("EETF", EETFname,std::string("/ee_fixed_link"));
-  nh.param("baseTF", baseTFname,std::string("/base_link"));
-  nh.param("add_solver_summary", addSolverSummary,false);
-  nh.param("load_transforms_from_file", loadTransformsFromFile, false);
-  nh.param("transform_pairs_record_filename", transformPairsRecordFile, std::string("TransformPairsInput.yml"));
-  nh.param("transform_pairs_load_filename", transformPairsLoadFile, std::string("TransformPairsOutput.yml"));
-  nh.param("output_calibrated_transform_filename", calibratedTransformFile,std::string("CalibratedTransform.yml"));
+    // getting TF names
+    nh.param("ARTagTF", ARTagTFname, std::string("/camera_2/ar_marker_0"));
+    nh.param("cameraTF", cameraTFname, std::string("/camera_2_link"));
+    nh.param("EETF", EETFname, std::string("/ee_fixed_link"));
+    nh.param("baseTF", baseTFname, std::string("/base_link"));
+    nh.param("add_solver_summary", addSolverSummary, false);
+    nh.param("load_transforms_from_file", loadTransformsFromFile, false);
+    nh.param("transform_pairs_record_filename", transformPairsRecordFile,
+             std::string("TransformPairsInput.yml"));
+    nh.param("transform_pairs_load_filename", transformPairsLoadFile,
+             std::string("TransformPairsOutput.yml"));
+    nh.param("output_calibrated_transform_filename", calibratedTransformFile,
+             std::string("CalibratedTransform.yml"));
 
-  std::cerr << "Calibrated output file: " << calibratedTransformFile << "\n";
+    std::cerr << "Calibrated output file: " << calibratedTransformFile << "\n";
 
+    if (loadTransformsFromFile) {
+        std::cerr << "Transform pairs loading file: " << transformPairsLoadFile
+                  << "\n";
+        EigenAffineVector t1, t2;
+        readTransformPairsFromFile(transformPairsLoadFile, t1, t2);
+        auto result =
+            estimateHandEye(t1, t2, calibratedTransformFile, addSolverSummary);
 
-  if(loadTransformsFromFile){
-	    std::cerr << "Transform pairs loading file: " << transformPairsLoadFile << "\n";
-	  	EigenAffineVector t1,t2;
-	  	readTransformPairsFromFile(transformPairsLoadFile,t1,t2);
-	  	auto result = estimateHandEye(t1,t2,calibratedTransformFile,addSolverSummary);
-
-	  	return 0;
-  }
-
-  std::cerr << "Transform pairs recording to file: " << transformPairsRecordFile << "\n";
-  
-  ros::Rate r(10); // 10 hz
-  listener = new(tf::TransformListener);
-
-  ros::Duration(1.0).sleep(); //cache the TF transforms
-  int key = 0;
-  ROS_INFO("Press s to add the current frame transformation to the cache.");
-  ROS_INFO("Press d to delete last frame transformation.");
-  ROS_INFO("Press q to calibrate frame transformation and exit the application.");
-
-  while (ros::ok())
-  {
-    key = getch();
-    if ((key == 's') || (key == 'S')){
-      std::cerr << "Adding Transform #:" << rvecsArm.size() << "\n";
-      addFrame();
-      writeTransformPairsToFile(baseToTip,cameraToTag,transformPairsRecordFile);
+        return 0;
     }
-  	else if ((key == 'd') || (key == 'D'))
-  	{
-  		ROS_INFO("Deleted last frame transformation. Number of Current Transformations: %u",(unsigned int)rvecsArm.size());
-  		rvecsArm.pop_back();
-  		tvecsArm.pop_back();
-  		rvecsFiducial.pop_back();
-  		tvecsFiducial.pop_back();
-  		baseToTip.pop_back();
-  		cameraToTag.pop_back();
-  	}
-    else if ((key == 'q') || (key == 'Q'))
-	{
-	  	if (rvecsArm.size() < 5)
-	  	{
-	  		ROS_WARN("Number of calibration transform pairs < 5.");
-				ROS_INFO("Node Quit");
-	  	}
-	  	ROS_INFO("Calculating Calibration...");
-	  	camodocal::HandEyeCalibration calib;
-	  	Eigen::Matrix4d result;
-      ceres::Solver::Summary summary;
 
-      if (addSolverSummary) {
-        calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial,
-                                   tvecsFiducial, result, summary, false);
-      }
-      else
-        {
-          calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial,
-                                     tvecsFiducial, result, false);
+    std::cerr << "Transform pairs recording to file: "
+              << transformPairsRecordFile << "\n";
+
+    ros::Rate r(10); // 10 hz
+    listener = new (tf::TransformListener);
+
+    ros::Duration(1.0).sleep(); // cache the TF transforms
+    int key = 0;
+    ROS_INFO("Press s to add the current frame transformation to the cache.");
+    ROS_INFO("Press d to delete last frame transformation.");
+    ROS_INFO(
+        "Press q to calibrate frame transformation and exit the application.");
+
+    while (ros::ok()) {
+        key = getch();
+        if ((key == 's') || (key == 'S')) {
+            std::cerr << "Adding Transform #:" << rvecsArm.size() << "\n";
+            addFrame();
+            writeTransformPairsToFile(baseToTip, cameraToTag,
+                                      transformPairsRecordFile);
+        } else if ((key == 'd') || (key == 'D')) {
+            ROS_INFO("Deleted last frame transformation. Number of Current "
+                     "Transformations: %u",
+                     (unsigned int)rvecsArm.size());
+            rvecsArm.pop_back();
+            tvecsArm.pop_back();
+            rvecsFiducial.pop_back();
+            tvecsFiducial.pop_back();
+            baseToTip.pop_back();
+            cameraToTag.pop_back();
+        } else if ((key == 'q') || (key == 'Q')) {
+            if (rvecsArm.size() < 5) {
+                ROS_WARN("Number of calibration transform pairs < 5.");
+                ROS_INFO("Node Quit");
+            }
+            ROS_INFO("Calculating Calibration...");
+            camodocal::HandEyeCalibration calib;
+            Eigen::Matrix4d result;
+            ceres::Solver::Summary summary;
+
+            if (addSolverSummary) {
+                calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial,
+                                           tvecsFiducial, result, summary,
+                                           false);
+            } else {
+                calib.estimateHandEyeScrew(rvecsArm, tvecsArm, rvecsFiducial,
+                                           tvecsFiducial, result, false);
+            }
+
+            std::cerr << "Quaternion values are output in wxyz order\n";
+
+            std::cerr << "Calibration result (" << ARTagTFname << " pose in "
+                      << EETFname << " frame): \n"
+                      << result << std::endl;
+            Eigen::Transform<double, 3, Eigen::Affine> resultAffine(result);
+            std::cerr << "Translation (x,y,z) : "
+                      << resultAffine.translation().transpose() << std::endl;
+            Eigen::Quaternion<double> quaternionResult(resultAffine.rotation());
+            std::stringstream ss;
+            ss << quaternionResult.w() << " " << quaternionResult.x() << " "
+               << quaternionResult.y() << " " << quaternionResult.z()
+               << std::endl;
+            std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
+
+            if (addSolverSummary) {
+                writeCalibration(resultAffine, calibratedTransformFile,
+                                 summary);
+            } else {
+                writeCalibration(resultAffine, calibratedTransformFile);
+            }
+
+            Eigen::Transform<double, 3, Eigen::Affine> resultAffineInv =
+                resultAffine.inverse();
+            std::cerr << "Inverted Calibration result (" << EETFname
+                      << " pose in " << ARTagTFname << " frame): \n";
+            std::cerr << "Translation (x,y,z): "
+                      << resultAffineInv.translation().transpose() << std::endl;
+            quaternionResult =
+                Eigen::Quaternion<double>(resultAffineInv.rotation());
+            ss.clear();
+            ss << quaternionResult.w() << " " << quaternionResult.x() << " "
+               << quaternionResult.y() << " " << quaternionResult.z()
+               << std::endl;
+            std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
+
+            break;
+        } else {
+            std::cerr << key << " pressed.\n";
         }
+        r.sleep();
+    }
 
-
-	    	std::cerr << "Quaternion values are output in wxyz order\n";
-	    
-	  	std::cerr << "Calibration result (" << ARTagTFname << " pose in " << EETFname << " frame): \n"
-	  		<< result << std::endl;
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffine(result);
-	  	std::cerr << "Translation (x,y,z) : " << resultAffine.translation().transpose() << std::endl;
-	  	Eigen::Quaternion<double> quaternionResult (resultAffine.rotation());
-	  	std::stringstream ss;
-	  	ss << quaternionResult.w() << " " << quaternionResult.x() << " " << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
-
-	  	if (addSolverSummary) {
-        writeCalibration(resultAffine, calibratedTransformFile, summary);
-      }
-      else
-        {
-          writeCalibration(resultAffine, calibratedTransformFile);
-        }
-
-	  	Eigen::Transform<double,3,Eigen::Affine> resultAffineInv = resultAffine.inverse();
-	  	std::cerr << "Inverted Calibration result (" << EETFname << " pose in " << ARTagTFname << " frame): \n";
-	  	std::cerr << "Translation (x,y,z): " << resultAffineInv.translation().transpose() << std::endl;
-	  	quaternionResult = Eigen::Quaternion<double>(resultAffineInv.rotation());
-	  	ss.clear();
-	  	ss << quaternionResult.w() << " " << quaternionResult.x() << " " << quaternionResult.y() << " " << quaternionResult.z() << std::endl;
-	  	std::cerr << "Rotation (w,x,y,z): " << ss.str() << std::endl;
-	  	
-
-	  	break;
-	}
-	else
-	{
-		std::cerr << key << " pressed.\n";
-	}
-    r.sleep();
-  }
-
-  ros::shutdown();
-  return (0);
+    ros::shutdown();
+    return (0);
 }


### PR DESCRIPTION
Format the codebase with the defaults from the LLVM style, but with 4 columns indentation.
Style option are in the .clang-format
Build on top of PR #14 